### PR TITLE
add frozen version plugins logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Simply add the GitHub repository path for the beta Obsidian plugin to the list f
 1. Install BRAT from the Community Plugins in Obsidian 
 2. Get the link to the GitHub repository you want to test. The plugin developer can provide you with this link. 
     > It will look something like: GitMurf/my-plugin or https://github.com/GitMurf/my-plugin
-3. Open the command palette and run the command **BRAT: Add a beta plugin for testing**
+3. Open the command palette and run the command **BRAT: Add a beta plugin for testing** (If you want the plugin version to be frozen, use the command **BRAT: Add a beta plugin with frozen version for testing**.)
 4. Using the link from step 2, copy that into the modal that opens up
 5. Click on **Add Plugin** -- wait a few seconds and BRAT will tell you what is going on
 6. After BRAT confirms the installation, in Settings go to the **Community plugins ** tab.

--- a/help/plugins.md
+++ b/help/plugins.md
@@ -28,5 +28,5 @@ This is the info you need: The GitHub user name for the developer followed by th
 
 `TfTHacker/obsidian42-brat`
 
-That is all you need. Once you have the repository path, open the command palette and find the "Add a beta plugin for testing" command and then you will be prompted for the repository path. Once you add it, this will install the beta plugin into your vault.
+That is all you need. Once you have the repository path, open the command palette and find the "Add a beta plugin for testing" (or "Add a beta plugin with frozen version for testing") command and then you will be prompted for the repository path. Once you add it, this will install the beta plugin into your vault.
 

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -12,6 +12,7 @@ export default class AddNewPluginModal extends Modal {
     betaPlugins: BetaPlugins;
     address: string;
     openSettingsTabAfterwards: boolean;
+    version: string;
 
     constructor(plugin: ThePlugin, betaPlugins: BetaPlugins, openSettingsTabAfterwards = false) {
         super(plugin.app);
@@ -19,6 +20,7 @@ export default class AddNewPluginModal extends Modal {
         this.betaPlugins = betaPlugins;
         this.address = "";
         this.openSettingsTabAfterwards = openSettingsTabAfterwards;
+        this.version = "";
     }
 
     async submitForm(): Promise<void> {
@@ -28,7 +30,7 @@ export default class AddNewPluginModal extends Modal {
             ToastMessage(this.plugin, `This plugin is already in the list for beta testing`, 10);
             return;
         }
-        const result = await this.betaPlugins.addPlugin(scrubbedAddress);
+        const result = await this.betaPlugins.addPlugin(scrubbedAddress, false, false, false, this.version);
         if (result) {
             this.close();
         }
@@ -39,7 +41,7 @@ export default class AddNewPluginModal extends Modal {
         this.contentEl.createEl('form', {}, (formEl) => {
             new Setting(formEl)
                 .addText((textEl) => {
-                    textEl.setPlaceholder('Repository (example: TfTHacker/obsidian-brat');
+                    textEl.setPlaceholder('Repository (example: TfTHacker/obsidian-brat)');
                     textEl.onChange((value) => {
                         this.address = value.trim();
                     });
@@ -54,6 +56,18 @@ export default class AddNewPluginModal extends Modal {
                         const title = document.querySelector(".setting-item-info");
                         if (title) title.remove();
                         textEl.inputEl.focus()
+                    }, 10);
+                });
+            new Setting(formEl)
+                .addText((textEl) => {
+                    textEl.setPlaceholder('Specify Version If Needed (example: 1.0.0), Leave It Empty If Not Needed');
+                    textEl.onChange((value) => {
+                        this.version = value.trim();
+                    });
+                    textEl.inputEl.style.width = "100%";
+                    window.setTimeout(() => {
+                        const title = document.querySelector(".setting-item-info");
+                        if (title) title.remove();
                     }, 10);
                 });
 

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -12,14 +12,16 @@ export default class AddNewPluginModal extends Modal {
     betaPlugins: BetaPlugins;
     address: string;
     openSettingsTabAfterwards: boolean;
+    readonly useFrozenVersion: boolean;
     version: string;
 
-    constructor(plugin: ThePlugin, betaPlugins: BetaPlugins, openSettingsTabAfterwards = false) {
+    constructor(plugin: ThePlugin, betaPlugins: BetaPlugins, openSettingsTabAfterwards = false, useFrozenVersion = false) {
         super(plugin.app);
         this.plugin = plugin;
         this.betaPlugins = betaPlugins;
         this.address = "";
         this.openSettingsTabAfterwards = openSettingsTabAfterwards;
+        this.useFrozenVersion = useFrozenVersion;
         this.version = "";
     }
 
@@ -47,8 +49,13 @@ export default class AddNewPluginModal extends Modal {
                     });
                     textEl.inputEl.addEventListener('keydown', async (e: KeyboardEvent) => {
                         if (e.key === 'Enter' && this.address !== ' ') {
-                            e.preventDefault();
-                            await this.submitForm();
+                            if (
+                                (this.useFrozenVersion && this.version !== "") 
+                                || (!this.useFrozenVersion)
+                            ) {
+                                e.preventDefault();
+                                await this.submitForm();
+                            }
                         }
                     });
                     textEl.inputEl.style.width = "100%";
@@ -58,18 +65,21 @@ export default class AddNewPluginModal extends Modal {
                         textEl.inputEl.focus()
                     }, 10);
                 });
-            new Setting(formEl)
-                .addText((textEl) => {
-                    textEl.setPlaceholder('Specify Version If Needed (example: 1.0.0), Leave It Empty If Not Needed');
-                    textEl.onChange((value) => {
-                        this.version = value.trim();
+
+            if (this.useFrozenVersion) {
+                new Setting(formEl)
+                    .addText((textEl) => {
+                        textEl.setPlaceholder('Specify The Version (example: 1.0.0)');
+                        textEl.onChange((value) => {
+                            this.version = value.trim();
+                        });
+                        textEl.inputEl.style.width = "100%";
+                        window.setTimeout(() => {
+                            const title = document.querySelector(".setting-item-info");
+                            if (title) title.remove();
+                        }, 10);
                     });
-                    textEl.inputEl.style.width = "100%";
-                    window.setTimeout(() => {
-                        const title = document.querySelector(".setting-item-info");
-                        if (title) title.remove();
-                    }, 10);
-                });
+            }
 
             formEl.createDiv('modal-button-container', (buttonContainerEl) => {
                 buttonContainerEl
@@ -85,7 +95,14 @@ export default class AddNewPluginModal extends Modal {
             // invoked when button is clicked. 
             formEl.addEventListener('submit', async (e: Event) => {
                 e.preventDefault();
-                if (this.address !== '') await this.submitForm();
+                if (this.address !== '') {
+                    if (
+                        (this.useFrozenVersion && this.version !== "") 
+                        || (!this.useFrozenVersion)
+                    ) {
+                        await this.submitForm();
+                    }
+                }
             });
         });
     }

--- a/src/ui/PluginCommands.ts
+++ b/src/ui/PluginCommands.ts
@@ -13,29 +13,42 @@ export default class PluginCommands {
             icon: "BratIcon",
             name: "Plugins: Add a beta plugin for testing",
             showInRibbon: true,
-            callback: async () => { await this.plugin.betaPlugins.displayAddNewPluginModal() }
+            callback: async () => { await this.plugin.betaPlugins.displayAddNewPluginModal(false, false) }
+        },
+        {
+            id: "BRAT-AddBetaPluginWithFrozenVersion",
+            icon: "BratIcon",
+            name: "Plugins: Add a beta plugin with frozen version for testing",
+            showInRibbon: true,
+            callback: async () => { await this.plugin.betaPlugins.displayAddNewPluginModal(false, true) }
         },
         {
             id: "BRAT-checkForUpdatesAndUpdate",
             icon: "BratIcon",
-            name: "Plugins: Check for updates to all beta plugins and UPDATE",
+            name: "Plugins: Check for updates to all beta plugins w/o frozen version and UPDATE",
             showInRibbon: true,
             callback: async () => { await this.plugin.betaPlugins.checkForUpdatesAndInstallUpdates(true, false) }
         },
         {
             id: "BRAT-checkForUpdatesAndDontUpdate",
             icon: "BratIcon",
-            name: "Plugins: Only check for updates to beta plugins, but don't Update",
+            name: "Plugins: Only check for updates to beta plugins w/o frozen version, but don't Update",
             showInRibbon: true,
             callback: async () => { await this.plugin.betaPlugins.checkForUpdatesAndInstallUpdates(true, true) }
         },
         {
             id: "BRAT-updateOnePlugin",
             icon: "BratIcon",
-            name: "Plugins: Choose a single plugin to update",
+            name: "Plugins: Choose a single plugin w/o frozen version to update",
             showInRibbon: true,
             callback: async () => {
-                const pluginList: SuggesterItem[] = Object.values(this.plugin.settings.pluginList).map((m) => { return { display: m, info: m } });
+                const pluginSubListFrozenVersionNames = 
+                    new Set(this.plugin.settings.pluginSubListFrozenVersion.map(f => f.repo));
+                const pluginList: SuggesterItem[] = 
+                    Object
+                        .values(this.plugin.settings.pluginList)
+                        .filter((f) => !pluginSubListFrozenVersionNames.has(f))
+                        .map((m) => { return { display: m, info: m } });
                 const gfs = new GenericFuzzySuggester(this.plugin);
                 gfs.setSuggesterData(pluginList);
                 await gfs.display(async (results) => {

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -57,7 +57,7 @@ export class BratSettingsTab extends PluginSettingTab {
 
 		containerEl.createEl("hr");
 		containerEl.createEl("h2", { text: "Beta Plugin List" });
-		containerEl.createEl("div", { text: `The following is a list of beta plugins added via the command palette "Add a beta plugin for testing". ` });
+		containerEl.createEl("div", { text: `The following is a list of beta plugins added via the command palette "Add a beta plugin for testing" or "Add a beta plugin with frozen version for testing". ` });
 		containerEl.createEl("p");
 		containerEl.createEl("div", { text: `Click the x button next to a plugin to remove it from the list.` });
 		containerEl.createEl("p");
@@ -71,11 +71,16 @@ export class BratSettingsTab extends PluginSettingTab {
 				cb.onClick(async ()=>{
 					// @ts-ignore
 					this.plugin.app.setting.close();
-					await this.plugin.betaPlugins.displayAddNewPluginModal(true);
+					await this.plugin.betaPlugins.displayAddNewPluginModal(true, false);
 				})
 			});
 
+		const pluginSubListFrozenVersionNames
+			= new Set(this.plugin.settings.pluginSubListFrozenVersion.map(x => x.repo));
 		for (const bp of this.plugin.settings.pluginList) {
+			if (pluginSubListFrozenVersionNames.has(bp)) {
+				continue;
+			}
 			new Setting(containerEl)
 				.setName(bp)
 				.addButton((btn: ButtonComponent) => {
@@ -88,6 +93,33 @@ export class BratSettingsTab extends PluginSettingTab {
 						else {
 							btn.buttonEl.parentElement.parentElement.remove();
 							await this.plugin.betaPlugins.deletePlugin(bp)
+						}
+					});
+				})
+		}
+
+		new Setting(containerEl)
+			.addButton((cb: ButtonComponent)=>{
+				cb.setButtonText("Add Beta plugin with frozen version")
+				cb.onClick(async ()=>{
+					// @ts-ignore
+					this.plugin.app.setting.close();
+					await this.plugin.betaPlugins.displayAddNewPluginModal(true, true);
+				})
+			});
+		for (const bp of this.plugin.settings.pluginSubListFrozenVersion) {
+			new Setting(containerEl)
+				.setName(`${bp.repo} (version ${bp.version})`)
+				.addButton((btn: ButtonComponent) => {
+					btn.setIcon("cross");
+					btn.setTooltip("Delete this beta plugin");
+					btn.onClick(async () => {
+						// await this.plugin.betaPlugins.deletePlugin(bp);
+						if (btn.buttonEl.textContent === "")
+							btn.setButtonText("Click once more to confirm removal");
+						else {
+							btn.buttonEl.parentElement.parentElement.remove();
+							await this.plugin.betaPlugins.deletePlugin(bp.repo);
 						}
 					});
 				})

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -6,8 +6,14 @@ export interface ThemeInforamtion {
     lastUpdate: string;
 }
 
+export interface PluginFrozenVersion {
+    repo: string;
+    version: string;
+}
+
 export interface Settings {
     pluginList: string[];
+    pluginSubListFrozenVersion: PluginFrozenVersion[],
     themesList: ThemeInforamtion[];
     updateAtStartup: boolean;
     updateThemesAtStartup:  boolean;
@@ -21,6 +27,7 @@ export interface Settings {
 
 export const DEFAULT_SETTINGS: Settings = {
     pluginList: [],
+    pluginSubListFrozenVersion: [],
     themesList: [],
     updateAtStartup: false,
     updateThemesAtStartup: false,
@@ -37,12 +44,27 @@ export const DEFAULT_SETTINGS: Settings = {
  *
  * @param   {ThePlugin}      plugin         
  * @param   {string<void>}   repositoryPath  path to the GitHub repository
+ * @param   {string}         specifyVersion  if the plugin needs to stay at the frozen version, we need to also record the version
  *
  * @return  {Promise<void>}                  
  */
-export async function addBetaPluginToList(plugin: ThePlugin, repositoryPath: string): Promise<void> {
+export async function addBetaPluginToList(plugin: ThePlugin, repositoryPath: string, specifyVersion = ""): Promise<void> {
+    let save = false;
     if (!plugin.settings.pluginList.contains(repositoryPath)) {
         plugin.settings.pluginList.unshift(repositoryPath);
+        save = true;
+    }
+    if (
+        specifyVersion !== "" 
+        && (plugin.settings.pluginSubListFrozenVersion.filter(x => x.repo === repositoryPath).length === 0)
+    ) {
+        plugin.settings.pluginSubListFrozenVersion.unshift({
+            repo: repositoryPath,
+            version: specifyVersion
+        });
+        save = true;
+    }
+    if (save) {
         plugin.saveSettings();
     }
 }


### PR DESCRIPTION
So here is the implementation of the ideas from https://github.com/TfTHacker/obsidian42-brat/pull/32 .

The basic idea is adding `pluginSubListFrozenVersion` inside `data.json`, that is a sub list of `pluginList`. and add the corresponding logic of skipping items in sub list while updating any beta plugins.