### PR TITLE
Feat: enable beta plugin installation via Obsidian protocol

### DIFF
--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -48,24 +48,6 @@ export default class BetaPlugins {
   }
 
   /**
-   * Add a new beta plugin by opening a link "obsidian://brat?plugin=..."
-   * @param params - ObsidianProtocolData
-   */
-  async addNewPluginViaObsidianProtocol(params: ObsidianProtocolData): Promise<void> {
-    if (!params.plugin) {
-      toastMessage(
-        this.plugin,
-        `Could not locate the plugin repository from the URL.`,
-        10
-      );
-      return;
-    }
-    const modal = new AddNewPluginModal(this.plugin, this);
-    modal.address = params.plugin;
-    await modal.submitForm();
-  }
-
-  /**
    * Validates that a GitHub repository is plugin
    *
    * @param repositoryPath - GithubUser/RepositoryName (example: TfThacker/obsidian42-brat)

--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -48,11 +48,11 @@ export default class BetaPlugins {
   }
 
   /**
-   * Add a new beta plugin by opening a link "obsidian://brat?repo=..."
+   * Add a new beta plugin by opening a link "obsidian://brat?plugin=..."
    * @param params - ObsidianProtocolData
    */
   async addNewPluginViaObsidianProtocol(params: ObsidianProtocolData): Promise<void> {
-    if (!params.repo) {
+    if (!params.plugin) {
       toastMessage(
         this.plugin,
         `Could not locate the plugin repository from the URL.`,
@@ -61,7 +61,7 @@ export default class BetaPlugins {
       return;
     }
     const modal = new AddNewPluginModal(this.plugin, this);
-    modal.address = params.repo;
+    modal.address = params.plugin;
     await modal.submitForm();
   }
 

--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -4,7 +4,7 @@ import {
   grabManifestJsonFromRepository,
   grabReleaseFileFromRepository,
 } from './githubUtils';
-import type { ObsidianProtocolData, PluginManifest } from 'obsidian';
+import type { PluginManifest } from 'obsidian';
 import { normalizePath, Notice, requireApiVersion, apiVersion } from 'obsidian';
 import { addBetaPluginToList } from '../settings';
 import { toastMessage } from '../utils/notifications';
@@ -138,7 +138,7 @@ export default class BetaPlugins {
             'manifest.json',
             this.plugin.settings.debuggingMode
           )
-          : '',
+        : '',
       styles: await grabReleaseFileFromRepository(
         repositoryPath,
         version,
@@ -225,8 +225,9 @@ export default class BetaPlugins {
     }
 
     if (!Object.hasOwn(primaryManifest, 'version')) {
-      const msg = `${repositoryPath}\nThe manifest${usingBetaManifest ? '-beta' : ''
-        }.json file in the root directory of the repository does not have a version number in the file. This plugin cannot be installed.`;
+      const msg = `${repositoryPath}\nThe manifest${
+        usingBetaManifest ? '-beta' : ''
+      }.json file in the root directory of the repository does not have a version number in the file. This plugin cannot be installed.`;
       await this.plugin.log(msg, true);
       toastMessage(this.plugin, `${msg}`, noticeTimeout);
       return false;
@@ -237,7 +238,8 @@ export default class BetaPlugins {
       if (!requireApiVersion(primaryManifest.minAppVersion)) {
         const msg =
           `Plugin: ${repositoryPath}\n\n` +
-          `The manifest${usingBetaManifest ? '-beta' : ''
+          `The manifest${
+            usingBetaManifest ? '-beta' : ''
           }.json for this plugin indicates that the Obsidian ` +
           `version of the app needs to be ${primaryManifest.minAppVersion}, ` +
           `but this installation of Obsidian is ${apiVersion}. \n\nYou will need to update your ` +
@@ -354,7 +356,7 @@ export default class BetaPlugins {
           const msg = `There is an update available for ${primaryManifest.id} from version ${localManifestJson.version} to ${primaryManifest.version}. `;
           await this.plugin.log(
             msg +
-            `[Release Info](https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version})`,
+              `[Release Info](https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version})`,
             true
           );
           toastMessage(this.plugin, msg, 30, () => {
@@ -371,7 +373,7 @@ export default class BetaPlugins {
           const msg = `${primaryManifest.id}\nPlugin has been updated from version ${localManifestJson.version} to ${primaryManifest.version}. `;
           await this.plugin.log(
             msg +
-            `[Release Info](https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version})`,
+              `[Release Info](https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version})`,
             true
           );
           toastMessage(this.plugin, msg, 30, () => {
@@ -502,12 +504,12 @@ export default class BetaPlugins {
       (p) => p.manifest
     );
     return enabled ?
-      manifests.filter((manifest) =>
-        enabledPlugins.find((pluginName) => manifest.id === pluginName.id)
-      )
+        manifests.filter((manifest) =>
+          enabledPlugins.find((pluginName) => manifest.id === pluginName.id)
+        )
       : manifests.filter(
-        (manifest) =>
-          !enabledPlugins.find((pluginName) => manifest.id === pluginName.id)
-      );
+          (manifest) =>
+            !enabledPlugins.find((pluginName) => manifest.id === pluginName.id)
+        );
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ export default class ThePlugin extends Plugin {
 
     addIcons();
     this.showRibbonButton();
+    this.registerObsidianProtocolHandler('brat', this.betaPlugins.addNewPluginViaObsidianProtocol.bind(this.betaPlugins));
 
     this.app.workspace.onLayoutReady(() => {
       // let obsidian load and calm down before checking for updates

--- a/src/ui/AddNewTheme.ts
+++ b/src/ui/AddNewTheme.ts
@@ -26,7 +26,7 @@ export default class AddNewTheme extends Modal {
     if (existBetaThemeinInList(this.plugin, scrubbedAddress)) {
       toastMessage(
         this.plugin,
-        `This plugin is already in the list for beta testing`,
+        `This theme is already in the list for beta testing`,
         10
       );
       return;


### PR DESCRIPTION
Hi, thank you so much for maintaining this important infrastructure for the Obsidian community!

I've been wondering it might be great if I could add a button to README or the docs of my beta plugin that allows us to easily install the plugin by just clicking it. So I added an Obsidian protocol handler. Please let me know if you have any suggestions.

Example: 

```
[<button>Install via BRAT</button>](obsidian://brat?plugin=RyotaUshio/obsidian-enhanced-link-suggestions)
```

or 

```
[<button>Install via BRAT</button>](obsidian://brat?plugin=https://github.com/RyotaUshio/obsidian-enhanced-link-suggestions)
```

https://github.com/TfTHacker/obsidian42-brat/assets/72342591/16d5ca7f-4f0c-4e5f-b3f9-6536a217a16f

