### PR TITLE
feat: access for private repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # npm
 node_modules
 package-lock.json
+bun.lockb
 
 # build
 build

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,6 +24,7 @@ export interface Settings {
   loggingVerboseEnabled: boolean;
   debuggingMode: boolean;
   notificationsEnabled: boolean;
+  personalAccessToken?: string;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -38,6 +39,7 @@ export const DEFAULT_SETTINGS: Settings = {
   loggingVerboseEnabled: false,
   debuggingMode: false,
   notificationsEnabled: true,
+  personalAccessToken: '',
 };
 
 /**

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -240,5 +240,20 @@ export class BratSettingsTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         });
       });
+
+    new Setting(containerEl)
+      .setName('Personal Access Token')
+      .setDesc(
+        'If you need to access private repository, enter the personal access token here.'
+      )
+      .addText((text) => {
+        text
+          .setPlaceholder('Enter your personal access token')
+          .setValue(this.plugin.settings.personalAccessToken ?? '')
+          .onChange(async (value: string) => {
+            this.plugin.settings.personalAccessToken = value;
+            await this.plugin.saveSettings();
+          });
+      });
   }
 }


### PR DESCRIPTION
This implement #64 

![CleanShot 2024-01-10 at 14 49 40@2x](https://github.com/TfTHacker/obsidian42-brat/assets/43137033/b669d2f1-bc01-4fff-98ac-d9a49990c1ab)

This is implemented by using the GitHub API. If the repo is private, this will use the Github API instead of the browser download url. This operation require user to create a personal access token. 