### PR TITLE
feat: extend protocol handler to allow to set version number for plugin installs

### DIFF
--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -41,6 +41,7 @@ export default class BetaPlugins {
 		const newPlugin = new AddNewPluginModal(
 			this.plugin,
 			this,
+			"",
 			openSettingsTabAfterwards,
 			useFrozenVersion,
 		);

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,9 +80,19 @@ export default class BratPlugin extends Plugin {
 
 		for (const which of ["plugin", "theme"]) {
 			if (params[which]) {
-				const modal = which === "plugin" ? new AddNewPluginModal(this, this.betaPlugins) : new AddNewTheme(this);
-				modal.address = params[which];
-				modal.open();
+				let modal;
+				switch (which) {
+					case "plugin":
+						modal = new AddNewPluginModal(this, this.betaPlugins, params['version'] ?? "", true, params['version'] ? true : false);
+						modal.address = params[which];
+						modal.open();						break;
+					case "theme":
+						modal = new AddNewTheme(this);
+						modal.address = params[which];
+						modal.open();
+						break;
+				}
+
 				return;
 			}
 		}

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -20,6 +20,7 @@ export default class AddNewPluginModal extends Modal {
 	constructor(
 		plugin: BratPlugin,
 		betaPlugins: BetaPlugins,
+		version = "",
 		openSettingsTabAfterwards = false,
 		useFrozenVersion = false,
 	) {
@@ -30,7 +31,7 @@ export default class AddNewPluginModal extends Modal {
 		this.openSettingsTabAfterwards = openSettingsTabAfterwards;
 		this.useFrozenVersion = useFrozenVersion;
 		this.enableAfterInstall = plugin.settings.enableAfterInstall;
-		this.version = "";
+		this.version = version;
 	}
 
 	async submitForm(): Promise<void> {
@@ -93,6 +94,7 @@ export default class AddNewPluginModal extends Modal {
 					textEl.setPlaceholder(
 						"Specify the release version tag (example: 1.0.0)",
 					);
+					textEl.setValue(this.version);
 					textEl.onChange((value) => {
 						this.version = value.trim();
 					});


### PR DESCRIPTION
This PR extends the protocol handler with a `version` argument for plugins. This way, users can load a frozen version directly from an obsidian URI like [`obsidian://brat?plugin=TfTHacker/tester-rep-for-brat&version=1.0.3`](obsidian://brat?plugin=TfTHacker/tester-rep-for-brat&version=1.0.3). If already installed, the registered frozen version will not be changed but has to be manually removed.

This way, Obsidian plugin developers who wish to publish a beta version of their plugin for testing can simply add an obsidian://brat URI including the version number to their release notes (or announcements) and people can install this specific version with a click. 

TODO: It might be interesting to add a check to see if the plugin is already installed with a frozen version and if so, update  the registered frozen version to the new frozen version.
