### PR TITLE
feat: fetch available versions into dropdown when adding frozen version

### DIFF
--- a/src/features/githubUtils.ts
+++ b/src/features/githubUtils.ts
@@ -27,6 +27,34 @@ const isPrivateRepo = async (
 };
 
 /**
+ * Fetches available release versions from a GitHub repository
+ * 
+ * @param repository - path to GitHub repository in format USERNAME/repository
+ * @returns array of version strings, or null if error
+ */
+export const fetchReleaseVersions = async (
+	repository: string,
+	debugLogging = true,
+	personalAccessToken = "",
+): Promise<string[] | null> => {
+	const URL = `https://api.github.com/repos/${repository}/releases`;
+	try {
+		const response = await request({
+			url: URL,
+			headers: {
+				Authorization: `Token ${personalAccessToken}`,
+			},
+		});
+		const data = await JSON.parse(response);
+		return data.map((release: { tag_name: string }) => release.tag_name);
+	} catch (e) {
+		if (debugLogging) console.log("error in fetchReleaseVersions", URL, e);
+		return null;
+	}
+};
+
+
+/**
  * pulls from github a release file by its version number
  *
  * @param repository - path to GitHub repository in format USERNAME/repository

--- a/src/features/githubUtils.ts
+++ b/src/features/githubUtils.ts
@@ -1,6 +1,11 @@
 import type { PluginManifest } from "obsidian";
 import { request } from "obsidian";
 
+export interface ReleaseVersion {
+    version: string;   // The tag name of the release
+    prerelease: boolean; // Indicates if the release is a pre-release
+}
+
 const GITHUB_RAW_USERCONTENT_PATH = "https://raw.githubusercontent.com/";
 
 const isPrivateRepo = async (
@@ -36,7 +41,7 @@ export const fetchReleaseVersions = async (
 	repository: string,
 	debugLogging = true,
 	personalAccessToken = "",
-): Promise<string[] | null> => {
+): Promise<ReleaseVersion[] | null> => {
 	const URL = `https://api.github.com/repos/${repository}/releases`;
 	try {
 		const response = await request({
@@ -46,7 +51,10 @@ export const fetchReleaseVersions = async (
 			},
 		});
 		const data = await JSON.parse(response);
-		return data.map((release: { tag_name: string }) => release.tag_name);
+		return data.map((release: { tag_name: string, prerelease: boolean }) => ({
+			version: release.tag_name,
+			prerelease: release.prerelease
+		}));
 	} catch (e) {
 		if (debugLogging) console.log("error in fetchReleaseVersions", URL, e);
 		return null;

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -1,5 +1,5 @@
 import { Modal, Setting, type TextComponent } from "obsidian";
-import { fetchReleaseVersions } from "src/features/githubUtils";
+import { type ReleaseVersion, fetchReleaseVersions } from "src/features/githubUtils";
 import type BetaPlugins from "../features/BetaPlugins";
 import type BratPlugin from "../main";
 import { existBetaPluginInList } from "../settings";
@@ -65,12 +65,12 @@ export default class AddNewPluginModal extends Modal {
 		}
 	}
 
-    private updateVersionDropdown(settingEl: Setting, versions: string[]): void {
+    private updateVersionDropdown(settingEl: Setting, versions: ReleaseVersion[]): void {
 		settingEl.clear();
 		settingEl.addDropdown((dropdown) => {
                 dropdown.addOption("", "Select a version");
                 for (const version of versions) {
-                    dropdown.addOption(version, version);
+                    dropdown.addOption(version.version, `${version.version} ${version.prerelease ? "(Prerelease)" : ""}`);
                 }
                 dropdown.onChange((value) => {
                     this.version = value;

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,13 @@
 .brat-modal .modal-button-container {
 	margin-top: 5px !important;
 }
+
+.brat-modal .valid-repository {
+	border-color: var(--color-green) !important;
+}
+.brat-modal .invalid-repository {
+	border-color: var(--color-red) !important;
+}
+.brat-modal .disabled-setting {
+	opacity: 0.5;
+}


### PR DESCRIPTION
This is a user-experience enhancement.

- Versions are presented as a dropdown (live-updated from GitHub releases) when a valid repository is entered
- Whenever the user presses "enter", or leaves the input field, we validate the repository and fetch the available versions (indicating pre-releases in the dropdown)
- The "Add Plugin" button is only enabled when a valid repository/version combo is selected

Open question: we indicate a valid repository by drawing a green border around the address, and red for invalid repositories. We also enable/disable the version dropdown respectively. Not sure this is good practice, but certainly helps the user when navigating the UI.

Ideas for further enhancement: 
- validate the repository/release for the presence of a "manifest.json" file