### PR TITLE
Add setting to use latest plugin version by default

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,7 @@ export interface Settings {
 	debuggingMode: boolean;
 	notificationsEnabled: boolean;
 	personalAccessToken?: string;
+	selectLatestPluginVersionByDefault: boolean;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -41,6 +42,7 @@ export const DEFAULT_SETTINGS: Settings = {
 	debuggingMode: false,
 	notificationsEnabled: true,
 	personalAccessToken: "",
+	selectLatestPluginVersionByDefault: false,
 };
 
 /**

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -121,6 +121,9 @@ export default class AddNewPluginModal extends Modal {
 
 	private updateVersionDropdown(settingEl: Setting, versions: ReleaseVersion[], selected = ""): void {
 		settingEl.clear();
+		if (versions.length > 0 && !selected && this.plugin.settings.selectLatestPluginVersionByDefault) {
+			selected = "latest";
+		}
 
 		const VERSION_THRESHOLD = 20;
 

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -123,7 +123,6 @@ export default class AddNewPluginModal extends Modal {
 		settingEl.clear();
 		if (versions.length > 0 && !selected && this.plugin.settings.selectLatestPluginVersionByDefault) {
 			selected = "latest";
-			this.updateAddButtonState();
 		}
 
 		const VERSION_THRESHOLD = 20;
@@ -137,11 +136,13 @@ export default class AddNewPluginModal extends Modal {
 				for (const version of versions) {
 					dropdown.addOption(version.version, `${version.version} ${version.prerelease ? "(Prerelease)" : ""}`);
 				}
-				dropdown.setValue(selected);
-				dropdown.onChange((value) => {
+				const changeHandler = (value: string) => {
 					this.version = value;
 					this.updateAddButtonState();
-				});
+				};
+				dropdown.onChange(changeHandler);
+				dropdown.setValue(selected);
+				changeHandler(selected);
 
 				dropdown.selectEl.addClass("brat-version-selector");
 				dropdown.selectEl.style.width = "100%";

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -120,9 +120,13 @@ export default class AddNewPluginModal extends Modal {
 	}
 
 	private updateVersionDropdown(settingEl: Setting, versions: ReleaseVersion[], selected = ""): void {
+		let selectedVersion: string;
+
 		settingEl.clear();
 		if (versions.length > 0 && !selected && this.plugin.settings.selectLatestPluginVersionByDefault) {
-			selected = "latest";
+			selectedVersion = "latest";
+		} else {
+			selectedVersion = selected;
 		}
 
 		const VERSION_THRESHOLD = 20;
@@ -141,8 +145,8 @@ export default class AddNewPluginModal extends Modal {
 					this.updateAddButtonState();
 				};
 				dropdown.onChange(changeHandler);
-				dropdown.setValue(selected);
-				changeHandler(selected);
+				dropdown.setValue(selectedVersion);
+				changeHandler(selectedVersion);
 
 				dropdown.selectEl.addClass("brat-version-selector");
 				dropdown.selectEl.style.width = "100%";
@@ -151,7 +155,7 @@ export default class AddNewPluginModal extends Modal {
 			// Use suggest modal for many versions
 			settingEl.addButton((button) => {
 				button
-					.setButtonText(selected === "latest" ? "Latest version" : selected || "Select a version...")
+					.setButtonText(selectedVersion === "latest" ? "Latest version" : selectedVersion || "Select a version...")
 					.setClass("brat-version-selector")
 					.setClass("button")
 					.onClick((e: Event) => {
@@ -161,7 +165,7 @@ export default class AddNewPluginModal extends Modal {
 							prerelease: false,
 						};
 						const suggestedVersions: ReleaseVersion[] = [latest, ...versions];
-						const modal = new VersionSuggestModal(this.app, this.address, suggestedVersions, selected, (version: string) => {
+						const modal = new VersionSuggestModal(this.app, this.address, suggestedVersions, selectedVersion, (version: string) => {
 							this.version = version;
 							button.setButtonText(version === "latest" ? "Latest version" : version || "Select a version...");
 							this.updateAddButtonState();

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -123,6 +123,7 @@ export default class AddNewPluginModal extends Modal {
 		settingEl.clear();
 		if (versions.length > 0 && !selected && this.plugin.settings.selectLatestPluginVersionByDefault) {
 			selected = "latest";
+			this.updateAddButtonState();
 		}
 
 		const VERSION_THRESHOLD = 20;

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -59,6 +59,16 @@ export class BratSettingsTab extends PluginSettingTab {
 				});
 			});
 
+		new Setting(containerEl)
+			.setName("Select latest plugin version by default")
+			.setDesc("If enabled the latest version will be selected by default when adding a new plugin.")
+			.addToggle((cb: ToggleComponent) => {
+				cb.setValue(this.plugin.settings.selectLatestPluginVersionByDefault).onChange(async (value: boolean) => {
+					this.plugin.settings.selectLatestPluginVersionByDefault = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
 		promotionalLinks(containerEl, true);
 		containerEl.createEl("hr");
 		new Setting(containerEl).setName("Beta plugin list").setHeading();


### PR DESCRIPTION
Fixes #120 

That's an alternative implementation to #121. The difference is that in the current PR, the default behavior is configurable.