### PR TITLE
Update error logging in grabReleaseFileFromRepository

### DIFF
--- a/src/features/githubUtils.ts
+++ b/src/features/githubUtils.ts
@@ -353,7 +353,7 @@ export const grabReleaseFileFromRepository = async (
 			throw error;
 		}
 		if (debugLogging)
-			console.log("error in grabReleaseFileFromRepository", URL, error);
+			console.log("error in grabReleaseFileFromRepository", release, error);
 		return null;
 	}
 };


### PR DESCRIPTION
Fixes a small typo. I assume this was supposed to print something about the url/release that failed (instead of the `URL` class ;-))