### PR TITLE
fix: correct typo in settings tab

### DIFF
--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -304,7 +304,7 @@ export class BratSettingsTab extends PluginSettingTab {
 					url: "https://github.com/settings/tokens/new?scopes=public_repo",
 					text: "your GitHub account settings",
 					appendText:
-						" and then add it here. Please consult the documetation for more details.",
+						" and then add it here. Please consult the documentation for more details.",
 				}),
 			)
 			.addText((text) => {


### PR DESCRIPTION
## Summary
- Fixed spelling error: "documetation" → "documentation"

## Details
In `src/ui/SettingsTab.ts`, the personal access token setting description contained a typo. This PR corrects it.

## Test plan
- [x] Verified the change is purely cosmetic (single character fix)
- [x] No functional changes