### PR TITLE
[FEAT]: Add i18n support for settings and plugin modal

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,22 @@
+import { getLanguage } from "obsidian";
+import { en, type LocaleStrings } from "./locales/en";
+import { zhCn } from "./locales/zh-cn";
+
+const locales: Record<string, LocaleStrings> = {
+	en,
+	"zh-cn": zhCn,
+};
+
+function normalizeLanguage(language: string): string {
+	const normalizedLanguage = language.toLowerCase().replace(/_/g, "-");
+
+	if (normalizedLanguage === "zh" || normalizedLanguage === "zh-cn" || normalizedLanguage === "zh-hans") {
+		return "zh-cn";
+	}
+
+	return normalizedLanguage;
+}
+
+export function getTranslations(): LocaleStrings {
+	return locales[normalizeLanguage(getLanguage())] ?? en;
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -32,7 +32,7 @@ function resolveLocale(language: string): string {
 	}
 
 	const baseLanguage = normalizedLanguage.split("-")[0];
-	return localeAliases[baseLanguage] ?? baseLanguage;
+	return locales[baseLanguage] ? baseLanguage : normalizedLanguage;
 }
 
 export function getTranslations(language = getLanguage()): LocaleStrings {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -7,16 +7,34 @@ const locales: Record<string, LocaleStrings> = {
 	"zh-cn": zhCn,
 };
 
+const localeAliases: Record<string, string> = {
+	"en-gb": "en",
+	"en-us": "en",
+	zh: "zh-cn",
+	"zh-hans": "zh-cn",
+	"zh-sg": "zh-cn",
+};
+
 function normalizeLanguage(language: string): string {
-	const normalizedLanguage = language.toLowerCase().replace(/_/g, "-");
-
-	if (normalizedLanguage === "zh" || normalizedLanguage === "zh-cn" || normalizedLanguage === "zh-hans") {
-		return "zh-cn";
-	}
-
-	return normalizedLanguage;
+	return language.toLowerCase().replace(/_/g, "-");
 }
 
-export function getTranslations(): LocaleStrings {
-	return locales[normalizeLanguage(getLanguage())] ?? en;
+function resolveLocale(language: string): string {
+	const normalizedLanguage = normalizeLanguage(language);
+
+	if (locales[normalizedLanguage]) {
+		return normalizedLanguage;
+	}
+
+	const alias = localeAliases[normalizedLanguage];
+	if (alias) {
+		return alias;
+	}
+
+	const baseLanguage = normalizedLanguage.split("-")[0];
+	return localeAliases[baseLanguage] ?? baseLanguage;
+}
+
+export function getTranslations(language = getLanguage()): LocaleStrings {
+	return locales[resolveLocale(language)] ?? en;
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,9 +1,13 @@
 import { getLanguage } from "obsidian";
+import { de } from "./locales/de";
 import { en, type LocaleStrings } from "./locales/en";
+import { ja } from "./locales/ja";
 import { zhCn } from "./locales/zh-cn";
 
 const locales: Record<string, LocaleStrings> = {
+	de,
 	en,
+	ja,
 	"zh-cn": zhCn,
 };
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -1,0 +1,159 @@
+import type { LocaleStrings } from "./en";
+
+export const de = {
+	common: {
+		and: " und ",
+		promotional: {
+			learnMore: "Mehr über meine Arbeit:",
+		},
+	},
+	settings: {
+		general: {
+			autoEnablePluginsAfterInstallation: {
+				name: "Beta-Plugins nach der Installation automatisch aktivieren",
+				desc: "Wenn aktiviert, werden neu installierte Beta-Plugins standardmäßig automatisch aktiviert. Diese Option kann im Formular zum Hinzufügen eines Plugins pro Plugin angepasst werden.",
+			},
+			autoUpdatePluginsAtStartup: {
+				name: "Beta-Plugins beim Start automatisch aktualisieren",
+				desc: "Wenn aktiviert, prüft BRAT bei jedem Start von Obsidian alle Beta-Plugins auf Updates. Plugins mit fixierter Version werden nicht aktualisiert.",
+			},
+			autoUpdateThemesAtStartup: {
+				name: "Beta-Themes beim Start automatisch aktualisieren",
+				desc: "Wenn aktiviert, prüft BRAT bei jedem Start von Obsidian alle Beta-Themes auf Updates.",
+			},
+			selectLatestPluginVersionByDefault: {
+				name: "Neueste Plugin-Version standardmäßig auswählen",
+				desc: "Wenn aktiviert, wird beim Hinzufügen eines neuen Plugins standardmäßig die neueste Version ausgewählt.",
+			},
+			allowIncompatiblePlugins: {
+				name: "Inkompatible Plugins erlauben",
+				desc: "Wenn aktiviert, können Plugins installiert werden, die eine höhere Obsidian-Version voraussetzen. Außerdem können Desktop-only-Plugins auf Mobilgeräten installiert werden.",
+			},
+		},
+		monitoring: {
+			heading: "Überwachung",
+			enableNotifications: {
+				name: "Benachrichtigungen aktivieren",
+				desc: "Wenn aktiviert, zeigt BRAT Popup-Benachrichtigungen zu verschiedenen Aktivitäten an. Wenn deaktiviert, werden keine Benachrichtigungen angezeigt.",
+			},
+			enableLogging: {
+				name: "Protokollierung aktivieren",
+				desc: "Plugin-Updates werden in eine Protokolldatei geschrieben.",
+			},
+			bratLogFileLocation: {
+				name: "Speicherort der BRAT-Protokolldatei",
+				desc: "Protokolle werden in dieser Datei gespeichert. Füge dem Dateinamen kein .md hinzu.",
+				placeholder: "Beispiel: BRAT-log",
+			},
+			enableVerboseLogging: {
+				name: "Ausführliche Protokollierung aktivieren",
+				desc: "Schreibt deutlich mehr Informationen in das Protokoll.",
+			},
+			debuggingMode: {
+				name: "Debug-Modus",
+				desc: "Sehr ausführliche Konsolenprotokollierung. Kann zur Fehlerbehebung und Entwicklung verwendet werden.",
+			},
+		},
+		githubPersonalAccessToken: {
+			heading: "GitHub Personal Access Token",
+			personalAccessToken: {
+				name: "Persönliches Zugriffstoken",
+				desc: {
+					prependText:
+						"Lege ein persönliches Zugriffstoken fest, um die Rate Limits für öffentliche GitHub-Repositorys zu erhöhen. Du kannst es in ",
+					linkText: "deinen GitHub-Kontoeinstellungen",
+					appendText: " erstellen und anschließend hier hinzufügen. Weitere Informationen findest du in der Dokumentation.",
+				},
+			},
+			clearPersonalAccessToken: "Persönliches Zugriffstoken löschen",
+			validate: "Validieren",
+		},
+		betaPluginList: {
+			heading: "Beta-Plugin-Liste",
+			filterPlaceholder: "Plugins filtern",
+			description: {
+				intro:
+					'Dies ist die Liste der Beta-Plugins, die über den Befehl "add a beta plugin for testing" hinzugefügt wurden. Du kannst die neueste Version verwenden oder eine Version fixieren. Eine fixierte Version ist ein bestimmtes Plugin-Release anhand seines Release-Tags.',
+				editAndRemove:
+					'Klicke auf die Schaltfläche "Bearbeiten" neben einem Plugin, um die installierte Version zu ändern. Klicke auf die Schaltfläche "X" neben einem Plugin, um es aus der Liste zu entfernen.',
+				noteLabel: "Hinweis: ",
+				noteText:
+					"Das Entfernen aus der Liste löscht das Plugin nicht. Das sollte über den Bereich Community-Plugins in den Einstellungen erfolgen.",
+			},
+			addBetaPlugin: "Beta-Plugin hinzufügen",
+			trackedVersion: (version: string, frozen: boolean): string =>
+				` Verfolgte Version: ${version === "latest" ? "neueste Version" : version} ${frozen ? "(fixiert)" : ""}`,
+			incompatible: " (inkompatibel)",
+			secretMissing: (secretName: string): string => ` Secret nicht definiert oder leer: ${secretName}`,
+			secretMissingTitle:
+				"Ein Token-Name ist konfiguriert, aber das Secret fehlt. Füge das Secret hinzu oder aktualisiere die Plugin-Konfiguration.",
+			secretMissingTooltip: (secretName: string): string =>
+				`Secret fehlt: ${secretName}. Bitte füge das Secret hinzu oder aktualisiere die Plugin-Konfiguration.`,
+			checkAndUpdatePlugin: "Plugin prüfen und aktualisieren",
+			changeVersionAndUpdateSettings: "Version ändern und Einstellungen aktualisieren",
+			removeThisBetaPlugin: "Dieses Beta-Plugin entfernen",
+			confirmRemoval: "Zum Bestätigen erneut klicken",
+		},
+		betaThemeList: {
+			heading: "Beta-Theme-Liste",
+			addBetaTheme: "Beta-Theme hinzufügen",
+			filterPlaceholder: "Themes filtern",
+			deleteThisBetaTheme: "Dieses Beta-Theme löschen",
+			confirmRemoval: "Zum Bestätigen erneut klicken",
+		},
+	},
+	addBetaPluginModal: {
+		buttons: {
+			addPlugin: "Plugin hinzufügen",
+			changeVersion: "Version ändern",
+			installing: "Wird installiert …",
+			neverMind: "Abbrechen",
+			valid: "Gültig",
+			invalid: "Ungültig",
+		},
+		heading: {
+			changePluginVersion: "Plugin-Version ändern: ",
+			githubRepositoryForBetaPlugin: "GitHub-Repository für das Beta-Plugin:",
+		},
+		repository: {
+			label: "Repository",
+			placeholder: "Repository (Beispiel: https://GitHub.com/githubusername/repository-name)",
+			enterAddressToValidate: "Gib eine GitHub-Repository-Adresse ein, um sie zu validieren.",
+			addressRequired: "Repository-Adresse ist erforderlich.",
+			validating: "Repository-Adresse wird validiert...",
+			noReleasesFound: "Fehler: In diesem Repository wurden keine Releases gefunden.",
+			notFound: "Repository nicht gefunden. Prüfe die Adresse oder gib ein gültiges Token für den Zugriff auf ein privates Repository an.",
+			accessDenied: "Zugriff verweigert. Prüfe dein persönliches Zugriffstoken.",
+			error: (message: string): string => `Fehler: ${message}`,
+			rateLimitExceeded: (minutes: number): string => `GitHub API Rate Limit überschritten. Versuche es in ${minutes} Minuten erneut.`,
+			rateLimitToast: (message: string): string =>
+				`${message} Du kannst in den BRAT-Einstellungen ein persönliches Zugriffstoken hinzufügen, um höhere Limits zu erhalten. Siehe Dokumentation für Details.`,
+			gitHubResponseToast: (message: string): string => `${message} `,
+		},
+		version: {
+			selectVersion: "Version auswählen",
+			selectVersionEllipsis: "Version auswählen...",
+			latestVersion: "Neueste Version",
+			prereleaseSuffix: "(Vorabversion)",
+		},
+		token: {
+			name: "GitHub-Token",
+			desc: "Wähle ein Secret als Token für dieses Repository aus (optional)",
+			settingCleared: (repository: string): string => `Token-Einstellung für ${repository} gelöscht`,
+			settingUpdated: (repository: string): string => `Token-Einstellung für ${repository} aktualisiert`,
+		},
+		enableAfterInstall: "Plugin nach der Installation aktivieren",
+		alreadyInList: "Dieses Plugin ist bereits in der Beta-Testliste",
+	},
+	versionSuggestModal: {
+		title: "Version auswählen",
+		placeholder: (repository: string): string => `Version für ${repository} suchen`,
+		versionLabel: (version: string): string => (version === "latest" ? "Neueste Version" : version),
+		instructions: {
+			navigateVersions: "Versionen durchsuchen",
+			selectVersion: "Version auswählen",
+			dismissModal: "Dialog schließen",
+		},
+		prereleaseSuffix: "(Vorabversion)",
+	},
+} satisfies LocaleStrings;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,155 @@
+export const en = {
+	common: {
+		and: " and ",
+		promotional: {
+			learnMore: "Learn more about my work at:",
+		},
+	},
+	settings: {
+		general: {
+			autoEnablePluginsAfterInstallation: {
+				name: "Auto-enable plugins after installation",
+				desc: 'If enabled beta plugins will be automatically enabled after installtion by default. Note: you can toggle this on and off for each plugin in the "add plugin" form.',
+			},
+			autoUpdatePluginsAtStartup: {
+				name: "Auto-update plugins at startup",
+				desc: "If enabled all beta plugins will be checked for updates each time Obsidian starts. Note: this does not update frozen version plugins.",
+			},
+			autoUpdateThemesAtStartup: {
+				name: "Auto-update themes at startup",
+				desc: "If enabled all beta themes will be checked for updates each time Obsidian starts.",
+			},
+			selectLatestPluginVersionByDefault: {
+				name: "Select latest plugin version by default",
+				desc: "If enabled the latest version will be selected by default when adding a new plugin.",
+			},
+			allowIncompatiblePlugins: {
+				name: "Allow incompatible plugins",
+				desc: "If enabled, plugins with higher app versions will be allowed to be installed. Also it allows desktop-only plugins to be installed on mobile devices.",
+			},
+		},
+		monitoring: {
+			heading: "Monitoring",
+			enableNotifications: {
+				name: "Enable notifications",
+				desc: "BRAT will provide popup notifications for its various activities. Turn this off means no notifications.",
+			},
+			enableLogging: {
+				name: "Enable logging",
+				desc: "Plugin updates will be logged to a file in the log file.",
+			},
+			bratLogFileLocation: {
+				name: "BRAT log file location",
+				desc: "Logs will be saved to this file. Don't add .md to the file name.",
+				placeholder: "Example: BRAT-log",
+			},
+			enableVerboseLogging: {
+				name: "Enable verbose logging",
+				desc: "Get a lot  more information in  the log.",
+			},
+			debuggingMode: {
+				name: "Debugging mode",
+				desc: "Atomic bomb level console logging. Can be used for troubleshooting and development.",
+			},
+		},
+		githubPersonalAccessToken: {
+			heading: "GitHub Personal Access Token",
+			personalAccessToken: {
+				name: "Personal access token",
+				desc: {
+					prependText: "Set a personal access token to increase rate limits for public repositories on GitHub. You can create one in ",
+					linkText: "your GitHub account settings",
+					appendText: " and then add it here. Please consult the documentation for more details.",
+				},
+			},
+			clearPersonalAccessToken: "Clear personal access token",
+			validate: "Validate",
+		},
+		betaPluginList: {
+			heading: "Beta plugin list",
+			filterPlaceholder: "Filter plugins",
+			description: {
+				intro:
+					'The following is a list of beta plugins added via the command "add a beta plugin for testing". You can chose to add the latest version or a frozen version. A frozen version is a specific release of a plugin based on its release tag.',
+				editAndRemove:
+					'Click the "edit" button next to a plugin to change the installed version. Click the "X" button next to a plugin to remove it from the list.',
+				noteLabel: "Note: ",
+				noteText: "Removing from the list does not delete the plugin, this should be done from the Community Plugins tab in Settings.",
+			},
+			addBetaPlugin: "Add beta plugin",
+			trackedVersion: (version: string, frozen: boolean): string => ` Tracked version: ${version} ${frozen ? "(frozen)" : ""}`,
+			incompatible: " (incompatible)",
+			secretMissing: (secretName: string): string => ` Secret not defined or empty: ${secretName}`,
+			secretMissingTitle: "Token name configured but secret is missing. Add the secret or update the plugin configuration.",
+			secretMissingTooltip: (secretName: string): string =>
+				`Secret missing: ${secretName}. Please add the secret or update the plugin configuration.`,
+			checkAndUpdatePlugin: "Check and update plugin",
+			changeVersionAndUpdateSettings: "Change version and update settings",
+			removeThisBetaPlugin: "Remove this beta plugin",
+			confirmRemoval: "Click once more to confirm removal",
+		},
+		betaThemeList: {
+			heading: "Beta themes list",
+			addBetaTheme: "Add beta theme",
+			filterPlaceholder: "Filter themes",
+			deleteThisBetaTheme: "Delete this beta theme",
+			confirmRemoval: "Click once more to confirm removal",
+		},
+	},
+	addBetaPluginModal: {
+		buttons: {
+			addPlugin: "Add plugin",
+			changeVersion: "Change version",
+			installing: "Installing …",
+			neverMind: "Never mind",
+			valid: "Valid",
+			invalid: "Invalid",
+		},
+		heading: {
+			changePluginVersion: "Change plugin version: ",
+			githubRepositoryForBetaPlugin: "GitHub repository for beta plugin:",
+		},
+		repository: {
+			label: "Repository",
+			placeholder: "Repository (example: https://GitHub.com/githubusername/repository-name)",
+			enterAddressToValidate: "Enter a GitHub repository address to validate it.",
+			addressRequired: "Repository address is required.",
+			validating: "Validating repository address...",
+			noReleasesFound: "Error: No releases found in this repository.",
+			notFound: "Repository not found. Check the address or provide a valid token for access to a private repository.",
+			accessDenied: "Access denied. Check your personal access token.",
+			error: (message: string): string => `Error: ${message}`,
+			rateLimitExceeded: (minutes: number): string => `GitHub API rate limit exceeded. Try again in ${minutes} minutes.`,
+			rateLimitToast: (message: string): string =>
+				`${message} Consider adding a personal access token in BRAT settings for higher limits. See documentation for details.`,
+			gitHubResponseToast: (message: string): string => `${message} `,
+		},
+		version: {
+			selectVersion: "Select a version",
+			selectVersionEllipsis: "Select a version...",
+			latestVersion: "Latest version",
+			prereleaseSuffix: "(Prerelease)",
+		},
+		token: {
+			name: "GitHub token",
+			desc: "Select a secret as token for this repository (optional)",
+			settingCleared: (repository: string): string => `Token setting cleared for ${repository}`,
+			settingUpdated: (repository: string): string => `Token setting updated for ${repository}`,
+		},
+		enableAfterInstall: "Enable after installing the plugin",
+		alreadyInList: "This plugin is already in the list for beta testing",
+	},
+	versionSuggestModal: {
+		title: "Select a version",
+		placeholder: (repository: string): string => `Type to search for a version for ${repository}`,
+		versionLabel: (version: string): string => version,
+		instructions: {
+			navigateVersions: "Navigate versions",
+			selectVersion: "Select version",
+			dismissModal: "Dismiss modal",
+		},
+		prereleaseSuffix: "(Prerelease)",
+	},
+};
+
+export type LocaleStrings = typeof en;

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -1,0 +1,158 @@
+import type { LocaleStrings } from "./en";
+
+export const ja = {
+	common: {
+		and: " と ",
+		promotional: {
+			learnMore: "作者の他の作品を見る：",
+		},
+	},
+	settings: {
+		general: {
+			autoEnablePluginsAfterInstallation: {
+				name: "インストール後に Beta プラグインを自動で有効化",
+				desc: "有効にすると、新しくインストールした Beta プラグインは既定で自動的に有効になります。個別のプラグインについては「プラグインを追加」フォームで切り替えられます。",
+			},
+			autoUpdatePluginsAtStartup: {
+				name: "起動時に Beta プラグインを自動更新",
+				desc: "有効にすると、Obsidian の起動時にすべての Beta プラグインの更新を確認します。固定バージョンのプラグインは更新されません。",
+			},
+			autoUpdateThemesAtStartup: {
+				name: "起動時に Beta テーマを自動更新",
+				desc: "有効にすると、Obsidian の起動時にすべての Beta テーマの更新を確認します。",
+			},
+			selectLatestPluginVersionByDefault: {
+				name: "既定で最新のプラグインバージョンを選択",
+				desc: "有効にすると、新しいプラグインを追加するときに最新バージョンが既定で選択されます。",
+			},
+			allowIncompatiblePlugins: {
+				name: "互換性のないプラグインを許可",
+				desc: "有効にすると、より新しい Obsidian バージョンを必要とするプラグインをインストールできます。また、デスクトップ専用プラグインをモバイル端末にインストールすることも許可されます。",
+			},
+		},
+		monitoring: {
+			heading: "監視",
+			enableNotifications: {
+				name: "通知を有効化",
+				desc: "有効にすると、BRAT は各種アクティビティについてポップアップ通知を表示します。オフにすると通知は表示されません。",
+			},
+			enableLogging: {
+				name: "ログを有効化",
+				desc: "プラグインの更新はログファイルに記録されます。",
+			},
+			bratLogFileLocation: {
+				name: "BRAT ログファイルの場所",
+				desc: "ログはこのファイルに保存されます。ファイル名に .md は追加しないでください。",
+				placeholder: "例：BRAT-log",
+			},
+			enableVerboseLogging: {
+				name: "詳細ログを有効化",
+				desc: "ログにより多くの情報を記録します。",
+			},
+			debuggingMode: {
+				name: "デバッグモード",
+				desc: "非常に詳細なコンソールログを出力します。トラブルシューティングや開発に使用できます。",
+			},
+		},
+		githubPersonalAccessToken: {
+			heading: "GitHub 個人アクセストークン",
+			personalAccessToken: {
+				name: "個人アクセストークン",
+				desc: {
+					prependText: "個人アクセストークンを設定すると、GitHub の公開リポジトリに対するレート制限を緩和できます。トークンは ",
+					linkText: "GitHub アカウント設定",
+					appendText: " で作成し、ここに追加できます。詳しくはドキュメントを参照してください。",
+				},
+			},
+			clearPersonalAccessToken: "個人アクセストークンをクリア",
+			validate: "検証",
+		},
+		betaPluginList: {
+			heading: "Beta プラグイン一覧",
+			filterPlaceholder: "プラグインを絞り込み",
+			description: {
+				intro:
+					'以下は、"add a beta plugin for testing" コマンドで追加された Beta プラグインの一覧です。最新バージョンを使うことも、特定のバージョンに固定することもできます。固定バージョンとは、リリースタグに基づく特定のプラグインリリースです。',
+				editAndRemove:
+					"プラグイン横の「編集」ボタンをクリックすると、インストールするバージョンを変更できます。プラグイン横の「X」ボタンをクリックすると、一覧から削除できます。",
+				noteLabel: "注意：",
+				noteText: "一覧から削除してもプラグイン本体は削除されません。削除するには、設定のコミュニティプラグインタブから操作してください。",
+			},
+			addBetaPlugin: "Beta プラグインを追加",
+			trackedVersion: (version: string, frozen: boolean): string =>
+				` 追跡中のバージョン：${version === "latest" ? "最新バージョン" : version}${frozen ? "（固定）" : ""}`,
+			incompatible: "（互換性なし）",
+			secretMissing: (secretName: string): string => ` シークレットが未定義または空です：${secretName}`,
+			secretMissingTitle:
+				"トークン名は設定されていますが、シークレットが見つからないか空です。シークレットを追加するか、プラグイン設定を更新してください。",
+			secretMissingTooltip: (secretName: string): string =>
+				`シークレットが見つかりません：${secretName}。シークレットを追加するか、プラグイン設定を更新してください。`,
+			checkAndUpdatePlugin: "プラグインを確認して更新",
+			changeVersionAndUpdateSettings: "バージョンを変更して設定を更新",
+			removeThisBetaPlugin: "この Beta プラグインを削除",
+			confirmRemoval: "もう一度クリックして削除を確認",
+		},
+		betaThemeList: {
+			heading: "Beta テーマ一覧",
+			addBetaTheme: "Beta テーマを追加",
+			filterPlaceholder: "テーマを絞り込み",
+			deleteThisBetaTheme: "この Beta テーマを削除",
+			confirmRemoval: "もう一度クリックして削除を確認",
+		},
+	},
+	addBetaPluginModal: {
+		buttons: {
+			addPlugin: "プラグインを追加",
+			changeVersion: "バージョンを変更",
+			installing: "インストール中…",
+			neverMind: "キャンセル",
+			valid: "有効",
+			invalid: "無効",
+		},
+		heading: {
+			changePluginVersion: "プラグインのバージョンを変更：",
+			githubRepositoryForBetaPlugin: "Beta プラグインの GitHub リポジトリ：",
+		},
+		repository: {
+			label: "リポジトリ",
+			placeholder: "リポジトリ（例：https://GitHub.com/githubusername/repository-name）",
+			enterAddressToValidate: "検証する GitHub リポジトリアドレスを入力してください。",
+			addressRequired: "リポジトリアドレスが必要です。",
+			validating: "リポジトリアドレスを検証中...",
+			noReleasesFound: "エラー：このリポジトリにリリースが見つかりません。",
+			notFound:
+				"リポジトリが見つかりません。アドレスを確認するか、プライベートリポジトリにアクセスできる有効なトークンを指定してください。",
+			accessDenied: "アクセスが拒否されました。個人アクセストークンを確認してください。",
+			error: (message: string): string => `エラー：${message}`,
+			rateLimitExceeded: (minutes: number): string => `GitHub API のレート制限を超過しました。${minutes} 分後にもう一度お試しください。`,
+			rateLimitToast: (message: string): string =>
+				`${message} BRAT 設定で個人アクセストークンを追加すると、より高い制限を利用できます。詳しくはドキュメントを参照してください。`,
+			gitHubResponseToast: (message: string): string => `${message} `,
+		},
+		version: {
+			selectVersion: "バージョンを選択",
+			selectVersionEllipsis: "バージョンを選択...",
+			latestVersion: "最新バージョン",
+			prereleaseSuffix: "（プレリリース）",
+		},
+		token: {
+			name: "GitHub トークン",
+			desc: "このリポジトリ用のトークンとして使用するシークレットを選択します（任意）",
+			settingCleared: (repository: string): string => `${repository} のトークン設定をクリアしました`,
+			settingUpdated: (repository: string): string => `${repository} のトークン設定を更新しました`,
+		},
+		enableAfterInstall: "インストール後にプラグインを有効化",
+		alreadyInList: "このプラグインはすでに Beta テスト一覧にあります",
+	},
+	versionSuggestModal: {
+		title: "バージョンを選択",
+		placeholder: (repository: string): string => `${repository} のバージョンを検索`,
+		versionLabel: (version: string): string => (version === "latest" ? "最新バージョン" : version),
+		instructions: {
+			navigateVersions: "バージョンを移動",
+			selectVersion: "バージョンを選択",
+			dismissModal: "モーダルを閉じる",
+		},
+		prereleaseSuffix: "（プレリリース）",
+	},
+} satisfies LocaleStrings;

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -1,0 +1,153 @@
+import type { LocaleStrings } from "./en";
+
+export const zhCn = {
+	common: {
+		and: " 和 ",
+		promotional: {
+			learnMore: "了解作者的更多作品：",
+		},
+	},
+	settings: {
+		general: {
+			autoEnablePluginsAfterInstallation: {
+				name: "安装后自动启用 Beta 插件",
+				desc: "开启后，新安装的 Beta 插件会默认自动启用。你仍然可以在“添加插件”表单中为单个插件单独调整。",
+			},
+			autoUpdatePluginsAtStartup: {
+				name: "启动时自动更新 Beta 插件",
+				desc: "开启后，每次 Obsidian 启动时都会检查并安装 Beta 插件更新。固定版本不会自动更新。",
+			},
+			autoUpdateThemesAtStartup: {
+				name: "启动时自动更新 Beta 主题",
+				desc: "开启后，每次 Obsidian 启动时都会检查并安装 Beta 主题更新。",
+			},
+			selectLatestPluginVersionByDefault: {
+				name: "默认选择插件最新版本",
+				desc: "开启后，添加新插件时会默认选择最新版本。",
+			},
+			allowIncompatiblePlugins: {
+				name: "允许安装不兼容插件",
+				desc: "开启后，可以安装要求更高 Obsidian 版本的插件，也可以在移动端安装仅支持桌面端的插件。",
+			},
+		},
+		monitoring: {
+			heading: "通知与日志",
+			enableNotifications: {
+				name: "启用通知",
+				desc: "开启后，BRAT 会用弹窗提示安装、更新等操作状态。关闭后不再显示这些通知。",
+			},
+			enableLogging: {
+				name: "启用日志",
+				desc: "开启后，插件更新记录会写入日志文件。",
+			},
+			bratLogFileLocation: {
+				name: "BRAT 日志文件",
+				desc: "日志会保存到这个文件。填写文件名或库内路径时不要加 .md。",
+				placeholder: "示例：BRAT-log",
+			},
+			enableVerboseLogging: {
+				name: "启用详细日志",
+				desc: "开启后，日志会记录更多排查信息。",
+			},
+			debuggingMode: {
+				name: "调试模式",
+				desc: "开启后，控制台会输出大量调试信息，主要用于排查问题和开发。",
+			},
+		},
+		githubPersonalAccessToken: {
+			heading: "GitHub 个人访问令牌",
+			personalAccessToken: {
+				name: "个人访问令牌",
+				desc: {
+					prependText: "设置个人访问令牌可以提高访问 GitHub 公共仓库时的请求额度。你可以在 ",
+					linkText: "GitHub 令牌设置",
+					appendText: " 中创建令牌，然后在这里选择保存该令牌的密钥。更多信息请参考文档。",
+				},
+			},
+			clearPersonalAccessToken: "清除个人访问令牌设置",
+			validate: "验证",
+		},
+		betaPluginList: {
+			heading: "Beta 插件列表",
+			filterPlaceholder: "筛选插件",
+			description: {
+				intro:
+					"下方列出已通过 BRAT 添加的 Beta 插件。你可以让插件跟随最新版本，也可以固定到某个发布版本。固定版本指基于 release 标签指定的某个插件版本。",
+				editAndRemove: "点击插件旁的编辑按钮可以更改安装版本；点击 X 按钮会将它从列表中移除。",
+				noteLabel: "注意：",
+				noteText: "从列表中移除不会删除插件本体。如需删除插件，请到设置中的“第三方插件”页面操作。",
+			},
+			addBetaPlugin: "添加 Beta 插件",
+			trackedVersion: (version: string, frozen: boolean): string =>
+				`跟踪版本：${version === "latest" ? "最新版本" : version}${frozen ? "（固定）" : ""}`,
+			incompatible: "（不兼容）",
+			secretMissing: (secretName: string): string => `密钥未定义或为空：${secretName}`,
+			secretMissingTitle: "已配置密钥名称，但密钥不存在或为空。请添加密钥，或更新该插件配置。",
+			secretMissingTooltip: (secretName: string): string => `密钥缺失：${secretName}。请添加密钥，或更新该插件配置。`,
+			checkAndUpdatePlugin: "检查并更新插件",
+			changeVersionAndUpdateSettings: "更改版本和设置",
+			removeThisBetaPlugin: "移除此 Beta 插件",
+			confirmRemoval: "再次点击确认移除",
+		},
+		betaThemeList: {
+			heading: "Beta 主题列表",
+			addBetaTheme: "添加 Beta 主题",
+			filterPlaceholder: "筛选主题",
+			deleteThisBetaTheme: "删除此 Beta 主题",
+			confirmRemoval: "再次点击确认移除",
+		},
+	},
+	addBetaPluginModal: {
+		buttons: {
+			addPlugin: "添加插件",
+			changeVersion: "更改版本",
+			installing: "正在安装…",
+			neverMind: "取消",
+			valid: "有效",
+			invalid: "无效",
+		},
+		heading: {
+			changePluginVersion: "更改插件版本：",
+			githubRepositoryForBetaPlugin: "Beta 插件的 GitHub 仓库：",
+		},
+		repository: {
+			label: "仓库",
+			placeholder: "仓库（示例：https://GitHub.com/githubusername/repository-name）",
+			enterAddressToValidate: "输入 GitHub 仓库地址后会自动验证。",
+			addressRequired: "需要填写仓库地址。",
+			validating: "正在验证仓库地址...",
+			noReleasesFound: "错误：此仓库中没有找到发布版本。",
+			notFound: "找不到仓库。请检查地址，或提供可访问私有仓库的有效令牌。",
+			accessDenied: "访问被拒绝。请检查个人访问令牌。",
+			error: (message: string): string => `错误：${message}`,
+			rateLimitExceeded: (minutes: number): string => `GitHub API 请求额度已用尽。请在 ${minutes} 分钟后重试。`,
+			rateLimitToast: (): string => "GitHub API 请求额度已用尽。可以在 BRAT 设置中添加个人访问令牌以提高额度。详情请查看文档。",
+			gitHubResponseToast: (message: string): string => `${message} `,
+		},
+		version: {
+			selectVersion: "选择版本",
+			selectVersionEllipsis: "选择版本...",
+			latestVersion: "最新版本",
+			prereleaseSuffix: "（预发布）",
+		},
+		token: {
+			name: "GitHub 令牌",
+			desc: "选择一个密钥，作为访问此仓库的令牌（可选）",
+			settingCleared: (repository: string): string => `已清除 ${repository} 的令牌设置`,
+			settingUpdated: (repository: string): string => `已更新 ${repository} 的令牌设置`,
+		},
+		enableAfterInstall: "安装后启用此插件",
+		alreadyInList: "这个插件已经在 Beta 测试列表中",
+	},
+	versionSuggestModal: {
+		title: "选择版本",
+		placeholder: (repository: string): string => `输入关键词，搜索 ${repository} 的版本`,
+		versionLabel: (version: string): string => (version === "latest" ? "最新版本" : version),
+		instructions: {
+			navigateVersions: "浏览版本",
+			selectVersion: "选择版本",
+			dismissModal: "关闭弹窗",
+		},
+		prereleaseSuffix: "（预发布）",
+	},
+} satisfies LocaleStrings;

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -18,6 +18,7 @@ import {
 import { TokenValidator } from "src/utils/TokenValidator";
 import { createGitHubResourceLink } from "src/utils/utils";
 import type BetaPlugins from "../features/BetaPlugins";
+import { getTranslations } from "../i18n";
 import type BratPlugin from "../main";
 import { existBetaPluginInList, updatePluginTokenName } from "../settings";
 import { toastMessage } from "../utils/notifications";
@@ -72,6 +73,7 @@ export default class AddNewPluginModal extends Modal {
 	}
 
 	async submitForm(): Promise<void> {
+		const text = getTranslations().addBetaPluginModal;
 		if (this.address === "") return;
 		const scrubbedAddress = scrubRepositoryUrl(this.address);
 
@@ -98,7 +100,7 @@ export default class AddNewPluginModal extends Modal {
 			// Reset modal if we don't close (i.e. because plugin could not be installed)
 			this.cancelButton?.setDisabled(false);
 			this.addPluginButton?.setDisabled(false);
-			this.addPluginButton?.setButtonText("Add plugin");
+			this.addPluginButton?.setButtonText(text.buttons.addPlugin);
 			this.versionSetting?.setDisabled(false);
 
 			return;
@@ -107,7 +109,7 @@ export default class AddNewPluginModal extends Modal {
 		if (!this.version && existBetaPluginInList(this.plugin, scrubbedAddress)) {
 			toastMessage(
 				this.plugin,
-				"This plugin is already in the list for beta testing",
+				text.alreadyInList,
 				10,
 			);
 			return;
@@ -130,7 +132,7 @@ export default class AddNewPluginModal extends Modal {
 		// Reset modal if we don't close (i.e. because plugin could not be installed)
 		this.cancelButton?.setDisabled(false);
 		this.addPluginButton?.setDisabled(false);
-		this.addPluginButton?.setButtonText("Add plugin");
+		this.addPluginButton?.setButtonText(text.buttons.addPlugin);
 		this.versionSetting?.setDisabled(false);
 	}
 
@@ -139,6 +141,7 @@ export default class AddNewPluginModal extends Modal {
 		versions: ReleaseVersion[],
 		selected = "",
 	): void {
+		const text = getTranslations().addBetaPluginModal;
 		let selectedVersion: string;
 
 		settingEl.clear();
@@ -159,12 +162,12 @@ export default class AddNewPluginModal extends Modal {
 		if (versions.length < VERSION_THRESHOLD || Platform.isMobile) {
 			// Use dropdown for fewer versions
 			settingEl.addDropdown((dropdown) => {
-				dropdown.addOption("", "Select a version");
-				dropdown.addOption("latest", "Latest version");
+				dropdown.addOption("", text.version.selectVersion);
+				dropdown.addOption("latest", text.version.latestVersion);
 				for (const version of versions) {
 					dropdown.addOption(
 						version.version,
-						`${version.version} ${version.prerelease ? "(Prerelease)" : ""}`,
+						`${version.version} ${version.prerelease ? text.version.prereleaseSuffix : ""}`,
 					);
 				}
 				dropdown.onChange((value: string) => {
@@ -181,8 +184,8 @@ export default class AddNewPluginModal extends Modal {
 				button
 					.setButtonText(
 						selectedVersion === "latest"
-							? "Latest version"
-							: selectedVersion || "Select a version...",
+							? text.version.latestVersion
+							: selectedVersion || text.version.selectVersionEllipsis,
 					)
 					.setClass("brat-version-selector")
 					.setClass("button")
@@ -201,8 +204,8 @@ export default class AddNewPluginModal extends Modal {
 								this.version = version;
 								button.setButtonText(
 									version === "latest"
-										? "Latest version"
-										: version || "Select a version...",
+										? text.version.latestVersion
+										: version || text.version.selectVersionEllipsis,
 								);
 								this.addPluginButton?.setDisabled(this.version === "");
 							},
@@ -214,15 +217,17 @@ export default class AddNewPluginModal extends Modal {
 	}
 
 	onOpen(): void {
+		const text = getTranslations().addBetaPluginModal;
 		const heading = this.contentEl.createEl("h4");
 		if (this.address) {
-			heading.appendText("Change plugin version: ");
+			heading.appendText(text.heading.changePluginVersion);
 			heading.appendChild(createGitHubResourceLink(this.address));
 		} else {
-			heading.setText("GitHub repository for beta plugin:");
+			heading.setText(text.heading.githubRepositoryForBetaPlugin);
 		}
 
 		this.contentEl.createEl("form", {}, (formEl) => {
+			const commonText = getTranslations().common;
 			formEl.addClass("brat-modal");
 
 			if (!this.address || !this.updateVersion) {
@@ -234,7 +239,7 @@ export default class AddNewPluginModal extends Modal {
 						this.repositoryAddressEl = addressEl;
 
 						addressEl.setPlaceholder(
-							"Repository (example: https://GitHub.com/githubusername/repository-name)",
+							text.repository.placeholder,
 						);
 						addressEl.setValue(this.address);
 						addressEl.onChange((value) => {
@@ -299,7 +304,7 @@ export default class AddNewPluginModal extends Modal {
 						});
 
 						// FIXME
-						setting.setDesc("Repository");
+						setting.setDesc(text.repository.label);
 						addressEl.inputEl.addClass("brat-full-width-input");
 					});
 				});
@@ -309,7 +314,7 @@ export default class AddNewPluginModal extends Modal {
 			const validationStatusEl = formEl.createDiv("validation-status");
 			if (!this.address)
 				validationStatusEl.setText(
-					"Enter a GitHub repository address to validate it.",
+					text.repository.enterAddressToValidate,
 				);
 
 			// Then add version dropdown
@@ -322,8 +327,8 @@ export default class AddNewPluginModal extends Modal {
 			// Token setting section
 			const tokenElement = formEl.createDiv("token-setting");
 			new Setting(tokenElement)
-				.setName("GitHub token")
-				.setDesc("Select a secret as token for this repository (optional)")
+				.setName(text.token.name)
+				.setDesc(text.token.desc)
 				.addComponent((el) =>
 					new SecretComponent(this.plugin.app, el)
 						.setValue(this.secretName)
@@ -339,7 +344,7 @@ export default class AddNewPluginModal extends Modal {
 										updatePluginTokenName(this.plugin, this.address, "");
 										toastMessage(
 											this.plugin,
-											`Token setting cleared for ${this.address}`,
+											text.token.settingCleared(this.address),
 											3,
 										);
 									}
@@ -358,10 +363,10 @@ export default class AddNewPluginModal extends Modal {
 										this.address,
 									);
 									if (!this.validToken) {
-										this.validateButton?.setButtonText("Invalid");
+										this.validateButton?.setButtonText(text.buttons.invalid);
 										this.validateButton?.setDisabled(false);
 									} else {
-										this.validateButton?.setButtonText("Valid");
+										this.validateButton?.setButtonText(text.buttons.valid);
 										this.validateButton?.setDisabled(true);
 
 										// Update version dropdown when API key changes
@@ -380,7 +385,7 @@ export default class AddNewPluginModal extends Modal {
 												);
 												toastMessage(
 													this.plugin,
-													`Token setting updated for ${this.address}`,
+													text.token.settingUpdated(this.address),
 													3,
 												);
 											}
@@ -406,7 +411,7 @@ export default class AddNewPluginModal extends Modal {
 						.then((isValid) => {
 							this.validToken = isValid;
 							if (this.validToken) {
-								this.validateButton?.setButtonText("Valid");
+								this.validateButton?.setButtonText(text.buttons.valid);
 								this.validateButton?.setDisabled(true);
 							}
 						});
@@ -428,12 +433,12 @@ export default class AddNewPluginModal extends Modal {
 						checkboxEl.addEventListener("click", () => {
 							this.enableAfterInstall = checkboxEl.checked;
 						});
-						labelEl.appendText("Enable after installing the plugin");
+						labelEl.appendText(text.enableAfterInstall);
 					},
 				);
 
 				this.cancelButton = new ButtonComponent(buttonContainerEl)
-					.setButtonText("Never mind")
+					.setButtonText(text.buttons.neverMind)
 					.setClass("mod-cancel")
 					.onClick(() => {
 						this.close();
@@ -443,9 +448,9 @@ export default class AddNewPluginModal extends Modal {
 					.setButtonText(
 						this.updateVersion
 							? this.address
-								? "Change version"
-								: "Add plugin"
-							: "Add plugin",
+								? text.buttons.changeVersion
+								: text.buttons.addPlugin
+							: text.buttons.addPlugin,
 					)
 					.setCta()
 					.onClick(() => {
@@ -456,7 +461,7 @@ export default class AddNewPluginModal extends Modal {
 							) {
 								// Submit the form
 								this.addPluginButton?.setDisabled(true);
-								this.addPluginButton?.setButtonText("Installing …");
+								this.addPluginButton?.setButtonText(text.buttons.installing);
 								this.cancelButton?.setDisabled(true);
 								this.versionSetting?.setDisabled(true);
 								void this.submitForm();
@@ -477,7 +482,7 @@ export default class AddNewPluginModal extends Modal {
 				// eslint-disable-next-line obsidianmd/ui/sentence-case
 				text: "TFTHacker",
 			});
-			byTfThacker.appendText(" and ");
+			byTfThacker.appendText(commonText.and);
 			byTfThacker.createEl("a", {
 				href: "https://github.com/johannrichard",
 				// eslint-disable-next-line obsidianmd/ui/sentence-case
@@ -520,6 +525,7 @@ export default class AddNewPluginModal extends Modal {
 		selectedVersion = "",
 		validationStatusEl?: HTMLElement,
 	) {
+		const text = getTranslations().addBetaPluginModal;
 		const validateInputEl = this.repositoryAddressEl;
 		if (this.plugin.settings.debuggingMode) {
 			console.debug(
@@ -528,12 +534,12 @@ export default class AddNewPluginModal extends Modal {
 		}
 
 		if (!this.address) {
-			validationStatusEl?.setText("Repository address is required.");
+			validationStatusEl?.setText(text.repository.addressRequired);
 			validationStatusEl?.addClass("validation-status-error");
 			return;
 		}
 
-		validationStatusEl?.setText("Validating repository address...");
+		validationStatusEl?.setText(text.repository.validating);
 		validationStatusEl?.removeClass("validation-status-error");
 
 		if (this.versionSetting && this.updateVersion) {
@@ -587,9 +593,7 @@ export default class AddNewPluginModal extends Modal {
 				// Add invalid-repository class
 				validateInputEl?.inputEl.classList.remove("valid-repository");
 				validateInputEl?.inputEl.classList.add("invalid-repository");
-				validationStatusEl?.setText(
-					"Error: No releases found in this repository.",
-				);
+				validationStatusEl?.setText(text.repository.noReleasesFound);
 				validationStatusEl?.addClass("validation-status-error");
 
 				this.versionSetting?.settingEl.classList.add("disabled-setting");
@@ -602,7 +606,7 @@ export default class AddNewPluginModal extends Modal {
 				validateInputEl?.inputEl.classList.remove("valid-repository");
 				validateInputEl?.inputEl.classList.add("validation-error");
 				validationStatusEl?.setText(
-					`GitHub API rate limit exceeded. Try again in ${error.getMinutesToReset()} minutes.`,
+					text.repository.rateLimitExceeded(error.getMinutesToReset()),
 				);
 
 				if (this.versionSetting) {
@@ -613,7 +617,7 @@ export default class AddNewPluginModal extends Modal {
 
 				toastMessage(
 					this.plugin,
-					`${error.message} Consider adding a personal access token in BRAT settings for higher limits. See documentation for details.`,
+					text.repository.rateLimitToast(error.message),
 					20,
 					(): void => {
 						window.open(
@@ -629,17 +633,15 @@ export default class AddNewPluginModal extends Modal {
 				const gitHubError = error;
 				switch (gitHubError.status) {
 					case 404:
-						validationStatusEl?.setText(
-							"Repository not found. Check the address or provide a valid token for access to a private repository.",
-						);
+						validationStatusEl?.setText(text.repository.notFound);
 						break;
 					case 403:
-						validationStatusEl?.setText(
-							"Access denied. Check your personal access token.",
-						);
+						validationStatusEl?.setText(text.repository.accessDenied);
 						break;
 					default:
-						validationStatusEl?.setText(`Error: ${gitHubError.message}`);
+						validationStatusEl?.setText(
+							text.repository.error(gitHubError.message),
+						);
 						break;
 				}
 
@@ -648,7 +650,11 @@ export default class AddNewPluginModal extends Modal {
 				this.versionSetting?.setDisabled(true);
 				this.addPluginButton?.setDisabled(true);
 
-				toastMessage(this.plugin, `${gitHubError.message} `, 20);
+				toastMessage(
+					this.plugin,
+					text.repository.gitHubResponseToast(gitHubError.message),
+					20,
+				);
 			}
 		}
 	}

--- a/src/ui/Promotional.ts
+++ b/src/ui/Promotional.ts
@@ -1,4 +1,7 @@
+import { getTranslations } from "../i18n";
+
 export const promotionalLinks = (containerEl: HTMLElement, settingsTab = true): HTMLElement => {
+	const text = getTranslations().common.promotional;
 	const linksDiv = containerEl.createEl("div", { cls: "brat-promotional-links" });
 
 	if (!settingsTab) {
@@ -11,7 +14,7 @@ export const promotionalLinks = (containerEl: HTMLElement, settingsTab = true): 
 	twitterSpan.addClass("ex-twitter-span");
 	twitterSpan.addClass("brat-promotional-links-coffee");
 	const captionText = twitterSpan.createDiv();
-	captionText.innerText = "Learn more about my work at:";
+	captionText.innerText = text.learnMore;
 	twitterSpan.appendChild(captionText);
 	const twitterLink = twitterSpan.createEl("a", {
 		href: "https://tfthacker.com",

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -13,6 +13,7 @@ import {
 } from "obsidian";
 import { TokenValidator } from "src/utils/TokenValidator";
 import { themeDelete } from "../features/themes";
+import { getTranslations } from "../i18n";
 import type BratPlugin from "../main";
 import { createGitHubResourceLink, createLink } from "../utils/utils";
 import AddNewTheme from "./AddNewTheme";
@@ -34,12 +35,11 @@ export class BratSettingsTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 		containerEl.addClass("brat-settings");
+		const text = getTranslations().settings;
 
 		new Setting(containerEl)
-			.setName("Auto-enable plugins after installation")
-			.setDesc(
-				'If enabled beta plugins will be automatically enabled after installtion by default. Note: you can toggle this on and off for each plugin in the "add plugin" form.',
-			)
+			.setName(text.general.autoEnablePluginsAfterInstallation.name)
+			.setDesc(text.general.autoEnablePluginsAfterInstallation.desc)
 			.addToggle((cb: ToggleComponent) => {
 				cb.setValue(this.plugin.settings.enableAfterInstall).onChange(
 					async (value: boolean) => {
@@ -50,10 +50,8 @@ export class BratSettingsTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName("Auto-update plugins at startup")
-			.setDesc(
-				"If enabled all beta plugins will be checked for updates each time Obsidian starts. Note: this does not update frozen version plugins.",
-			)
+			.setName(text.general.autoUpdatePluginsAtStartup.name)
+			.setDesc(text.general.autoUpdatePluginsAtStartup.desc)
 			.addToggle((cb: ToggleComponent) => {
 				cb.setValue(this.plugin.settings.updateAtStartup).onChange(
 					async (value: boolean) => {
@@ -64,10 +62,8 @@ export class BratSettingsTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName("Auto-update themes at startup")
-			.setDesc(
-				"If enabled all beta themes will be checked for updates each time Obsidian starts.",
-			)
+			.setName(text.general.autoUpdateThemesAtStartup.name)
+			.setDesc(text.general.autoUpdateThemesAtStartup.desc)
 			.addToggle((cb: ToggleComponent) => {
 				cb.setValue(this.plugin.settings.updateThemesAtStartup).onChange(
 					async (value: boolean) => {
@@ -78,10 +74,8 @@ export class BratSettingsTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName("Select latest plugin version by default")
-			.setDesc(
-				"If enabled the latest version will be selected by default when adding a new plugin.",
-			)
+			.setName(text.general.selectLatestPluginVersionByDefault.name)
+			.setDesc(text.general.selectLatestPluginVersionByDefault.desc)
 			.addToggle((cb: ToggleComponent) => {
 				cb.setValue(
 					this.plugin.settings.selectLatestPluginVersionByDefault,
@@ -92,10 +86,8 @@ export class BratSettingsTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName("Allow incompatible plugins")
-			.setDesc(
-				"If enabled, plugins with higher app versions will be allowed to be installed. Also it allows desktop-only plugins to be installed on mobile devices.",
-			)
+			.setName(text.general.allowIncompatiblePlugins.name)
+			.setDesc(text.general.allowIncompatiblePlugins.desc)
 			.addToggle((cb: ToggleComponent) => {
 				cb.setValue(this.plugin.settings.allowIncompatiblePlugins).onChange(
 					async (value: boolean) => {
@@ -116,11 +108,11 @@ export class BratSettingsTab extends PluginSettingTab {
 		>();
 
 		const betaPluginGroup = new SettingGroup(containerEl).setHeading(
-			"Beta plugin list",
+			text.betaPluginList.heading,
 		);
 
 		betaPluginGroup.addSearch((cb) => {
-			cb.setPlaceholder("Filter plugins");
+			cb.setPlaceholder(text.betaPluginList.filterPlaceholder);
 
 			cb.onChange((value: string) => {
 				const filterValue = value.toLowerCase().trim();
@@ -141,22 +133,24 @@ export class BratSettingsTab extends PluginSettingTab {
 		betaPluginGroup.addSetting((setting) => {
 			const pluginListDescription = document.createDocumentFragment();
 			pluginListDescription.createEl("div", {
-				text: `The following is a list of beta plugins added via the command "add a beta plugin for testing". You can chose to add the latest version or a frozen version. A frozen version is a specific release of a plugin based on its release tag.`,
+				text: text.betaPluginList.description.intro,
 			});
 
 			pluginListDescription.createEl("p");
 			pluginListDescription.createEl("div", {
-				text: `Click the "edit" button next to a plugin to change the installed version. Click the "X" button next to a plugin to remove it from the list.`,
+				text: text.betaPluginList.description.editAndRemove,
 			});
 			pluginListDescription.createEl("p");
-			pluginListDescription.createEl("span").createEl("b", { text: "Note: " });
+			pluginListDescription
+				.createEl("span")
+				.createEl("b", { text: text.betaPluginList.description.noteLabel });
 			pluginListDescription.createSpan({
-				text: "Removing from the list does not delete the plugin, this should be done from the Community Plugins tab in Settings.",
+				text: text.betaPluginList.description.noteText,
 			});
 
 			setting.setDesc(pluginListDescription);
 			setting.addButton((cb: ButtonComponent) => {
-				cb.setButtonText("Add beta plugin")
+				cb.setButtonText(text.betaPluginList.addBetaPlugin)
 					.setCta()
 					.onClick(() => {
 						this.plugin.betaPlugins.displayAddNewPluginModal(true);
@@ -175,18 +169,22 @@ export class BratSettingsTab extends PluginSettingTab {
 
 				const pluginDescription = document.createDocumentFragment();
 				const trackedVersionText = bp?.version
-					? ` Tracked version: ${bp.version} ${bp.version === "latest" ? "" : "(frozen)"}`
+					? text.betaPluginList.trackedVersion(
+							bp.version,
+							bp.version !== "latest",
+						)
 					: "";
-				const incompatibleText = bp?.isIncompatible ? " (incompatible)" : "";
+				const incompatibleText = bp?.isIncompatible
+					? text.betaPluginList.incompatible
+					: "";
 				pluginDescription.createDiv({
 					text: `${trackedVersionText}${incompatibleText}`,
 				});
 				if (isSecretMissing) {
 					pluginDescription.createDiv({
-						text: ` Secret not defined or empty: ${secretName}`,
+						text: text.betaPluginList.secretMissing(secretName),
 						cls: "mod-warning",
-						title:
-							"Token name configured but secret is missing. Add the secret or update the plugin configuration.",
+						title: text.betaPluginList.secretMissingTitle,
 					});
 				}
 
@@ -209,14 +207,14 @@ export class BratSettingsTab extends PluginSettingTab {
 							btn
 								.setIcon("sync")
 								.setTooltip(
-									`Secret missing: ${secretName}. Please add the secret or update the plugin configuration.`,
+									text.betaPluginList.secretMissingTooltip(secretName),
 								)
 								.setWarning()
 								.setDisabled(true);
 						} else {
 							btn
 								.setIcon("sync")
-								.setTooltip("Check and update plugin")
+								.setTooltip(text.betaPluginList.checkAndUpdatePlugin)
 								.onClick(async () => {
 									await this.plugin.betaPlugins.updatePlugin(
 										p,
@@ -235,7 +233,7 @@ export class BratSettingsTab extends PluginSettingTab {
 					.addButton((btn: ButtonComponent) => {
 						btn
 							.setIcon("edit")
-							.setTooltip("Change version and update settings");
+							.setTooltip(text.betaPluginList.changeVersionAndUpdateSettings);
 
 						if (isSecretMissing) {
 							btn.setWarning();
@@ -255,11 +253,11 @@ export class BratSettingsTab extends PluginSettingTab {
 					.addButton((btn: ButtonComponent) => {
 						btn
 							.setIcon("cross")
-							.setTooltip("Remove this beta plugin")
+							.setTooltip(text.betaPluginList.removeThisBetaPlugin)
 							.setWarning()
 							.onClick(() => {
 								if (btn.buttonEl.textContent === "") {
-									btn.setButtonText("Click once more to confirm removal");
+									btn.setButtonText(text.betaPluginList.confirmRemoval);
 								} else {
 									const { buttonEl } = btn;
 									const { parentElement } = buttonEl;
@@ -278,12 +276,12 @@ export class BratSettingsTab extends PluginSettingTab {
 			{ container: HTMLElement; themeName: string }
 		>();
 		const betaThemeGroup = new SettingGroup(containerEl).setHeading(
-			"Beta themes list",
+			text.betaThemeList.heading,
 		);
 
 		betaThemeGroup.addSetting((setting) => {
 			setting.addButton((cb: ButtonComponent) => {
-				cb.setButtonText("Add beta theme")
+				cb.setButtonText(text.betaThemeList.addBetaTheme)
 					.setCta()
 					.onClick(() => {
 						this.plugin.app.setting.close();
@@ -293,7 +291,7 @@ export class BratSettingsTab extends PluginSettingTab {
 		});
 
 		betaThemeGroup.addSearch((cb) => {
-			cb.setPlaceholder("Filter themes");
+			cb.setPlaceholder(text.betaThemeList.filterPlaceholder);
 
 			cb.onChange((value: string) => {
 				const filterValue = value.toLowerCase().trim();
@@ -325,10 +323,10 @@ export class BratSettingsTab extends PluginSettingTab {
 				themeSettingContainer.addButton((btn: ButtonComponent) => {
 					btn
 						.setIcon("cross")
-						.setTooltip("Delete this beta theme")
+						.setTooltip(text.betaThemeList.deleteThisBetaTheme)
 						.onClick(() => {
 							if (btn.buttonEl.textContent === "")
-								btn.setButtonText("Click once more to confirm removal");
+								btn.setButtonText(text.betaThemeList.confirmRemoval);
 							else {
 								const { buttonEl } = btn;
 								const { parentElement } = buttonEl;
@@ -343,16 +341,13 @@ export class BratSettingsTab extends PluginSettingTab {
 		}
 
 		const monitoringGroup = new SettingGroup(containerEl).setHeading(
-			"Monitoring",
+			text.monitoring.heading,
 		);
 
 		monitoringGroup.addSetting((setting) => {
 			setting
-				.setName("Enable notifications")
-				.setDesc(
-					// eslint-disable-next-line obsidianmd/ui/sentence-case
-					"BRAT will provide popup notifications for its various activities. Turn this off means no notifications.",
-				)
+				.setName(text.monitoring.enableNotifications.name)
+				.setDesc(text.monitoring.enableNotifications.desc)
 				.addToggle((cb: ToggleComponent) => {
 					cb.setValue(this.plugin.settings.notificationsEnabled);
 					cb.onChange((value: boolean) => {
@@ -364,8 +359,8 @@ export class BratSettingsTab extends PluginSettingTab {
 
 		monitoringGroup.addSetting((setting) => {
 			setting
-				.setName("Enable logging")
-				.setDesc("Plugin updates will be logged to a file in the log file.")
+				.setName(text.monitoring.enableLogging.name)
+				.setDesc(text.monitoring.enableLogging.desc)
 				.addToggle((cb: ToggleComponent) => {
 					cb.setValue(this.plugin.settings.loggingEnabled).onChange(
 						(value: boolean) => {
@@ -378,13 +373,10 @@ export class BratSettingsTab extends PluginSettingTab {
 
 		monitoringGroup.addSetting((setting) => {
 			setting
-				// eslint-disable-next-line obsidianmd/ui/sentence-case
-				.setName("BRAT log file location")
-				.setDesc(
-					"Logs will be saved to this file. Don't add .md to the file name.",
-				)
+				.setName(text.monitoring.bratLogFileLocation.name)
+				.setDesc(text.monitoring.bratLogFileLocation.desc)
 				.addSearch((cb) => {
-					cb.setPlaceholder("Example: BRAT-log")
+					cb.setPlaceholder(text.monitoring.bratLogFileLocation.placeholder)
 						.setValue(this.plugin.settings.loggingPath)
 						.onChange((newFolder) => {
 							this.plugin.settings.loggingPath = newFolder;
@@ -395,8 +387,8 @@ export class BratSettingsTab extends PluginSettingTab {
 
 		monitoringGroup.addSetting((setting) => {
 			setting
-				.setName("Enable verbose logging")
-				.setDesc("Get a lot  more information in  the log.")
+				.setName(text.monitoring.enableVerboseLogging.name)
+				.setDesc(text.monitoring.enableVerboseLogging.desc)
 				.addToggle((cb: ToggleComponent) => {
 					cb.setValue(this.plugin.settings.loggingVerboseEnabled).onChange(
 						(value: boolean) => {
@@ -409,10 +401,8 @@ export class BratSettingsTab extends PluginSettingTab {
 
 		monitoringGroup.addSetting((setting) => {
 			setting
-				.setName("Debugging mode")
-				.setDesc(
-					"Atomic bomb level console logging. Can be used for troubleshooting and development.",
-				)
+				.setName(text.monitoring.debuggingMode.name)
+				.setDesc(text.monitoring.debuggingMode.desc)
 				.addToggle((cb: ToggleComponent) => {
 					cb.setValue(this.plugin.settings.debuggingMode).onChange(
 						(value: boolean) => {
@@ -425,21 +415,21 @@ export class BratSettingsTab extends PluginSettingTab {
 
 		// Personal access token setting
 		const tokenSection = new SettingGroup(containerEl).setHeading(
-			"GitHub Personal Access Token",
+			text.githubPersonalAccessToken.heading,
 		);
 
 		let currentTokenValue = "";
 		tokenSection.addSetting((tokenSetting) => {
-			tokenSetting.setName("Personal access token").setDesc(
-				createLink({
-					prependText:
-						"Set a personal access token to increase rate limits for public repositories on GitHub. You can create one in ",
-					url: "https://github.com/settings/tokens/new?scopes=public_repo",
-					text: "your GitHub account settings",
-					appendText:
-						" and then add it here. Please consult the documentation for more details.",
-				}),
-			);
+			tokenSetting
+				.setName(text.githubPersonalAccessToken.personalAccessToken.name)
+				.setDesc(
+					createLink({
+						prependText: text.githubPersonalAccessToken.personalAccessToken.desc.prependText,
+						url: "https://github.com/settings/tokens/new?scopes=public_repo",
+						text: text.githubPersonalAccessToken.personalAccessToken.desc.linkText,
+						appendText: text.githubPersonalAccessToken.personalAccessToken.desc.appendText,
+					}),
+				);
 
 			// Create SecretComponent - displays secret NAME selector
 			this.accessTokenSetting = new SecretComponentClass(
@@ -481,7 +471,7 @@ export class BratSettingsTab extends PluginSettingTab {
 			tokenSetting
 				.addExtraButton((cb: ExtraButtonComponent) => {
 					cb.setIcon("cross")
-						.setTooltip("Clear personal access token")
+						.setTooltip(text.githubPersonalAccessToken.clearPersonalAccessToken)
 						.onClick(async () => {
 							this.plugin.settings.globalTokenName = "";
 							await this.plugin.saveSettings();
@@ -494,7 +484,7 @@ export class BratSettingsTab extends PluginSettingTab {
 					this.accessTokenButton = btn;
 
 					btn
-						.setButtonText("Validate")
+						.setButtonText(text.githubPersonalAccessToken.validate)
 						.setCta()
 						.onClick(async () => {
 							if (currentTokenValue) {

--- a/src/ui/VersionSuggestModal.ts
+++ b/src/ui/VersionSuggestModal.ts
@@ -1,5 +1,6 @@
 import { type App, SuggestModal } from "obsidian";
 import type { ReleaseVersion } from "src/features/githubUtils";
+import { getTranslations } from "../i18n";
 
 export class VersionSuggestModal extends SuggestModal<ReleaseVersion> {
 	selected: string;
@@ -8,15 +9,16 @@ export class VersionSuggestModal extends SuggestModal<ReleaseVersion> {
 
 	constructor(app: App, repository: string, versions: ReleaseVersion[], selected: string, onChoose: (version: string) => void) {
 		super(app);
+		const text = getTranslations().versionSuggestModal;
 		this.versions = versions;
 		this.selected = selected;
 		this.onChoose = onChoose;
-		this.setTitle("Select a version");
-		this.setPlaceholder(`Type to search for a version for ${repository}`);
+		this.setTitle(text.title);
+		this.setPlaceholder(text.placeholder(repository));
 		this.setInstructions([
-			{ command: "↑↓", purpose: "Navigate versions" },
-			{ command: "↵", purpose: "Select version" },
-			{ command: "esc", purpose: "Dismiss modal" },
+			{ command: "↑↓", purpose: text.instructions.navigateVersions },
+			{ command: "↵", purpose: text.instructions.selectVersion },
+			{ command: "esc", purpose: text.instructions.dismissModal },
 		]);
 	}
 
@@ -26,8 +28,9 @@ export class VersionSuggestModal extends SuggestModal<ReleaseVersion> {
 	}
 
 	renderSuggestion(version: ReleaseVersion, el: HTMLElement) {
+		const text = getTranslations().versionSuggestModal;
 		el.createEl("div", {
-			text: `${version.version} ${version.prerelease ? "(Prerelease)" : ""}`,
+			text: `${text.versionLabel(version.version)} ${version.prerelease ? text.prereleaseSuffix : ""}`,
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Adds a lightweight i18n layer for BRAT with English as the default fallback.
- Uses Obsidian's current language via `getLanguage()`, without adding a plugin language setting or changing the `data.json` schema.
- Moves visible settings text, beta plugin/theme list text, the Add beta plugin modal, the version picker, and shared promotional text into typed locale strings.
- Includes Simplified Chinese, German, and Japanese locale files as initial examples of the structure.
- Preserves the existing English copy so this PR stays focused on i18n structure rather than copy editing.

## Design Notes
- Locale entry point: `src/i18n/index.ts`.
- Default source of truth for keys and types: `src/i18n/locales/en.ts` exports `LocaleStrings` from the English object shape.
- Locale files are plain TypeScript objects and use `satisfies LocaleStrings`, so missing or extra keys should be caught while developing.
- Locale resolution first checks an exact Obsidian language code, then configured aliases, then a supported base language. Unsupported languages fall back to English.
- `zh`, `zh-Hans`, and `zh-SG` map to `zh-cn`; unsupported Chinese variants such as `zh-TW` fall back to English until a Traditional Chinese locale is added.
- Future languages should only need a new `src/i18n/locales/<locale>.ts` file plus one registry entry in `src/i18n/index.ts`.

## Scope
- Covered in this PR: settings UI, beta plugin/theme list text, Add beta plugin modal, version picker, and shared promotional copy.
- Intentionally not changed: plugin ID, manifest metadata, release assets, settings keys, saved data shape, command IDs, or plugin language preferences.
- English strings are preserved as closely as possible, including existing wording, to keep the review focused on structure and i18n wiring.

## Validation
- `npm run build`
- `git diff --check upstream/beta...HEAD`
- `npx biome check src\i18n`
- `npx eslint src\i18n`

## Notes
- Rebased this PR onto `beta` after the base branch was changed, keeping the file list focused on the i18n changes.
- Full-project lint still reports existing issues on the current upstream baseline. The remaining reports I saw in `SettingsTab.ts` and `AddNewPluginModal.ts` match that baseline, so I kept this PR focused on i18n rather than introducing unrelated formatting or typing changes.
- The German and Japanese locales are included to show how the structure can grow beyond one language while still keeping English fallback behavior as the default safety net.