### PR TITLE
feat: :sparkles: migrate settings to declarative UI

### DIFF
--- a/BRAT-DEVELOPER-GUIDE.md
+++ b/BRAT-DEVELOPER-GUIDE.md
@@ -113,3 +113,28 @@ If you want to provide read-only access to a private repository (e.g. for privat
 ![image](https://github.com/user-attachments/assets/da16fb77-623e-4ee2-abf3-0b63ea216e89)
 
 ![image](https://github.com/user-attachments/assets/d2898fd5-17d8-49a9-be46-710382319d89)
+
+## Managing beta plugin and theme lists in settings
+
+The BRAT settings page includes lists for tracked beta plugins and themes.
+
+### Beta plugin list
+
+Use this list to manage repositories you added through the command **"add a beta plugin for testing"**.
+
+- You can track either:
+  - the **latest** release, or
+  - a **frozen** version.
+- A frozen version means BRAT tracks one specific release tag for that repository.
+- Click the **edit** button next to a plugin to change the tracked version and related settings.
+- Click the red **X** button next to a plugin to remove it from BRAT tracking.
+
+### Beta theme list
+
+Use this list to manage beta themes tracked by BRAT.
+
+- Click the red **X** button next to a theme to remove it from BRAT tracking.
+
+> [!NOTE]
+> Removing a plugin or theme from BRAT tracking does not uninstall it from your vault.
+> Remove installed plugins from Settings > Community plugins and installed themes from Settings > Appearance.

--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -1,29 +1,15 @@
 import type {} from "@obsidian-typings/obsidian-public-1.11.4";
 import type { PluginManifest } from "obsidian";
-import {
-	apiVersion,
-	Notice,
-	normalizePath,
-	Platform,
-	requireApiVersion,
-} from "obsidian";
+import { apiVersion, Notice, normalizePath, Platform, requireApiVersion } from "obsidian";
 import { compare as compareVersions, coerce as semverCoerce } from "semver";
 import { confirm } from "src/ui/ConfirmModal";
-import {
-	GHRateLimitError,
-	GitHubResponseError,
-} from "src/utils/GitHubAPIErrors";
+import { GHRateLimitError, GitHubResponseError } from "src/utils/GitHubAPIErrors";
 import type BratPlugin from "../main";
 import { addBetaPluginToList } from "../settings";
 import AddNewPluginModal from "../ui/AddNewPluginModal";
 import { isConnectedToInternet } from "../utils/internetconnection";
 import { toastMessage } from "../utils/notifications";
-import {
-	grabReleaseFileFromRepository,
-	grabReleaseFromRepository,
-	isPrivateRepo,
-	type Release,
-} from "./githubUtils";
+import { grabReleaseFileFromRepository, grabReleaseFromRepository, isPrivateRepo, type Release } from "./githubUtils";
 
 /**
  * all the files needed for a plugin based on the release files are hre
@@ -66,6 +52,7 @@ export default class BetaPlugins {
 		prefillRepo = "",
 		prefillVersion = "",
 		prefillSecretName = "",
+		onSubmitted?: () => void,
 	): void {
 		const newPlugin = new AddNewPluginModal(
 			this.plugin,
@@ -75,6 +62,7 @@ export default class BetaPlugins {
 			prefillRepo,
 			prefillVersion,
 			prefillSecretName,
+			onSubmitted,
 		);
 		newPlugin.open();
 	}
@@ -113,11 +101,7 @@ export default class BetaPlugins {
 		// GitHub API access might throw a rate limit
 		try {
 			// check if the repository is private
-			const isPrivate = await isPrivateRepo(
-				repositoryPath,
-				this.plugin.settings.debuggingMode,
-				token,
-			);
+			const isPrivate = await isPrivateRepo(repositoryPath, this.plugin.settings.debuggingMode, token);
 
 			// Grab the manifest.json for the latest release from the repository
 			const release: Release | null = await grabReleaseFromRepository(
@@ -136,12 +120,7 @@ export default class BetaPlugins {
 						`${repositoryPath}\nThis does not seem to be an obsidian plugin with valid releases, as there are no releases available.`,
 						noticeTimeout,
 					);
-					console.error(
-						"BRAT: validateRepository",
-						repositoryPath,
-						getBetaManifest,
-						reportIssues,
-					);
+					console.error("BRAT: validateRepository", repositoryPath, getBetaManifest, reportIssues);
 				}
 				return null;
 			}
@@ -162,12 +141,7 @@ export default class BetaPlugins {
 						`${repositoryPath}\nThis does not seem to be an obsidian plugin, as there is no manifest.json file.`,
 						noticeTimeout,
 					);
-					console.error(
-						"BRAT: validateRepository",
-						repositoryPath,
-						getBetaManifest,
-						reportIssues,
-					);
+					console.error("BRAT: validateRepository", repositoryPath, getBetaManifest, reportIssues);
 				}
 				return null;
 			}
@@ -207,12 +181,8 @@ export default class BetaPlugins {
 
 			const hasVersionMismatch =
 				expectedVersion && manifestVersion
-					? compareVersions(
-							expectedVersion.version,
-							manifestVersion.version,
-						) !== 0
-					: expectedVersion !== null &&
-						manifestJson.version !== release.tag_name;
+					? compareVersions(expectedVersion.version, manifestVersion.version) !== 0
+					: expectedVersion !== null && manifestJson.version !== release.tag_name;
 
 			if (hasVersionMismatch && expectedVersion) {
 				if (reportIssues)
@@ -237,9 +207,7 @@ export default class BetaPlugins {
 					`${error.message} Consider adding a personal access token in BRAT settings for higher limits. See documentation for details.`,
 					20,
 					(): void => {
-						window.open(
-							"https://github.com/TfTHacker/obsidian42-brat/blob/main/BRAT-DEVELOPER-GUIDE.md#github-api-rate-limits",
-						);
+						window.open("https://github.com/TfTHacker/obsidian42-brat/blob/main/BRAT-DEVELOPER-GUIDE.md#github-api-rate-limits");
 					},
 				);
 
@@ -255,11 +223,7 @@ export default class BetaPlugins {
 							noticeTimeout,
 						);
 					} else {
-						toastMessage(
-							this.plugin,
-							`${repositoryPath}\nGitHub API error ${error.status}: ${error.message}`,
-							noticeTimeout,
-						);
+						toastMessage(this.plugin, `${repositoryPath}\nGitHub API error ${error.status}: ${error.message}`, noticeTimeout);
 					}
 				}
 				console.error(`BRAT: validateRepository ${error}`);
@@ -287,21 +251,12 @@ export default class BetaPlugins {
 	 *
 	 * @returns all release files as strings based on the ReleaseFiles interface
 	 */
-	async getAllReleaseFiles(
-		repositoryPath: string,
-		getManifest: boolean,
-		specifyVersion = "",
-		tokenValue = "",
-	): Promise<ReleaseFiles> {
+	async getAllReleaseFiles(repositoryPath: string, getManifest: boolean, specifyVersion = "", tokenValue = ""): Promise<ReleaseFiles> {
 		// Use provided token for API calls
 		const token = tokenValue;
 
 		// check if the repository is private
-		const isPrivate = await isPrivateRepo(
-			repositoryPath,
-			this.plugin.settings.debuggingMode,
-			token,
-		);
+		const isPrivate = await isPrivateRepo(repositoryPath, this.plugin.settings.debuggingMode, token);
 
 		// Get the latest release from the repository
 		const release: Release | null = await grabReleaseFromRepository(
@@ -323,29 +278,11 @@ export default class BetaPlugins {
 		console.debug({ reallyGetManifestOrNot, version: release.tag_name });
 
 		return {
-			mainJs: await grabReleaseFileFromRepository(
-				release,
-				"main.js",
-				this.plugin.settings.debuggingMode,
-				isPrivate,
-				token,
-			),
+			mainJs: await grabReleaseFileFromRepository(release, "main.js", this.plugin.settings.debuggingMode, isPrivate, token),
 			manifest: reallyGetManifestOrNot
-				? await grabReleaseFileFromRepository(
-						release,
-						"manifest.json",
-						this.plugin.settings.debuggingMode,
-						isPrivate,
-						token,
-					)
+				? await grabReleaseFileFromRepository(release, "manifest.json", this.plugin.settings.debuggingMode, isPrivate, token)
 				: "",
-			styles: await grabReleaseFileFromRepository(
-				release,
-				"styles.css",
-				this.plugin.settings.debuggingMode,
-				isPrivate,
-				token,
-			),
+			styles: await grabReleaseFileFromRepository(release, "styles.css", this.plugin.settings.debuggingMode, isPrivate, token),
 		};
 	}
 
@@ -356,28 +293,15 @@ export default class BetaPlugins {
 	 * @param relFiles     - release file as strings, based on the ReleaseFiles interface
 	 *
 	 */
-	async writeReleaseFilesToPluginFolder(
-		betaPluginId: string,
-		relFiles: ReleaseFiles,
-	): Promise<void> {
+	async writeReleaseFilesToPluginFolder(betaPluginId: string, relFiles: ReleaseFiles): Promise<void> {
 		const pluginTargetFolderPath = `${normalizePath(`${this.plugin.app.vault.configDir}/plugins/${betaPluginId}`)}/`;
 		const { adapter } = this.plugin.app.vault;
 		if (!(await adapter.exists(pluginTargetFolderPath))) {
 			await adapter.mkdir(pluginTargetFolderPath);
 		}
-		await adapter.write(
-			`${pluginTargetFolderPath}main.js`,
-			relFiles.mainJs ?? "",
-		);
-		await adapter.write(
-			`${pluginTargetFolderPath}manifest.json`,
-			relFiles.manifest ?? "",
-		);
-		if (relFiles.styles)
-			await adapter.write(
-				`${pluginTargetFolderPath}styles.css`,
-				relFiles.styles,
-			);
+		await adapter.write(`${pluginTargetFolderPath}main.js`, relFiles.mainJs ?? "");
+		await adapter.write(`${pluginTargetFolderPath}manifest.json`, relFiles.manifest ?? "");
+		if (relFiles.styles) await adapter.write(`${pluginTargetFolderPath}styles.css`, relFiles.styles);
 	}
 
 	/**
@@ -432,31 +356,15 @@ export default class BetaPlugins {
 					);
 				}
 			} else if (this.plugin.settings.globalTokenName) {
-				tokenValue =
-					this.plugin.app.secretStorage.getSecret(
-						this.plugin.settings.globalTokenName,
-					) || "";
+				tokenValue = this.plugin.app.secretStorage.getSecret(this.plugin.settings.globalTokenName) || "";
 			}
 
 			const noticeTimeout = 10;
 			// attempt to get manifest-beta.json
-			let primaryManifest = await this.validateRepository(
-				repositoryPath,
-				true,
-				true,
-				specifyVersion,
-				tokenValue,
-			);
+			let primaryManifest = await this.validateRepository(repositoryPath, true, true, specifyVersion, tokenValue);
 			const usingBetaManifest: boolean = !!primaryManifest;
 			// attempt to get manifest.json
-			if (!usingBetaManifest)
-				primaryManifest = await this.validateRepository(
-					repositoryPath,
-					false,
-					true,
-					specifyVersion,
-					tokenValue,
-				);
+			if (!usingBetaManifest) primaryManifest = await this.validateRepository(repositoryPath, false, true, specifyVersion, tokenValue);
 
 			if (primaryManifest === null) {
 				const msg = `${repositoryPath}\nA manifest.json file does not exist in the latest release of the repository. This plugin cannot be installed.`;
@@ -477,11 +385,7 @@ export default class BetaPlugins {
 			// Check manifest minAppVersion and current version of Obisidan, don't load plugin if not compatible
 			if (Object.hasOwn(primaryManifest, "minAppVersion")) {
 				if (!requireApiVersion(primaryManifest.minAppVersion)) {
-					if (
-						specifyVersion === "" ||
-						specifyVersion === "latest" ||
-						!this.plugin.settings.allowIncompatiblePlugins
-					) {
+					if (specifyVersion === "" || specifyVersion === "latest" || !this.plugin.settings.allowIncompatiblePlugins) {
 						const msg = `Plugin: ${repositoryPath}\n\nThe manifest.json for this plugin indicates that the Obsidian version of the app needs to be ${primaryManifest.minAppVersion}, but this installation of Obsidian is ${apiVersion}. \n\nYou will need to update your Obsidian to use this plugin or contact the plugin developer for more information.`;
 						await this.plugin.log(msg, true);
 						toastMessage(this.plugin, msg, 30);
@@ -496,17 +400,13 @@ export default class BetaPlugins {
 							f.createEl("br");
 							f.appendText("The ");
 							f.createEl("code", { text: "manifest.json" });
-							f.appendText(
-								" for this plugin indicates that the Obsidian version of the app needs to be ",
-							);
+							f.appendText(" for this plugin indicates that the Obsidian version of the app needs to be ");
 							f.createEl("code", { text: primaryManifest.minAppVersion });
 							f.appendText(", but this installation of Obsidian is ");
 							f.createEl("code", { text: apiVersion });
 							f.appendText(".");
 							f.createEl("br");
-							f.appendText(
-								"Using this plugin is not recommended and may not work as expected. Use at your own risk.",
-							);
+							f.appendText("Using this plugin is not recommended and may not work as expected. Use at your own risk.");
 							f.createEl("br");
 							f.appendText("Do you want to install it anyways?");
 						}),
@@ -527,21 +427,13 @@ export default class BetaPlugins {
 			}
 
 			const getRelease = async () => {
-				const rFiles = await this.getAllReleaseFiles(
-					repositoryPath,
-					usingBetaManifest,
-					specifyVersion,
-					tokenValue,
-				);
+				const rFiles = await this.getAllReleaseFiles(repositoryPath, usingBetaManifest, specifyVersion, tokenValue);
 
 				console.debug("rFiles", rFiles);
 				// if beta, use that manifest, or if there is no manifest in release, use the primaryManifest
-				if (usingBetaManifest || rFiles.manifest === "")
-					rFiles.manifest = JSON.stringify(primaryManifest);
+				if (usingBetaManifest || rFiles.manifest === "") rFiles.manifest = JSON.stringify(primaryManifest);
 
-				const manifestObj = JSON.parse(
-					rFiles.manifest ?? "",
-				) as PluginManifestEx;
+				const manifestObj = JSON.parse(rFiles.manifest ?? "") as PluginManifestEx;
 
 				if (isIncompatible) {
 					manifestObj.brat = {
@@ -565,13 +457,9 @@ export default class BetaPlugins {
 								f.createEl("code", { text: "isDesktopOnly: true" });
 								f.appendText(", but you are using a mobile device.");
 								f.createEl("br");
-								f.appendText(
-									"Using this plugin is not recommended and may not work as expected. Use at your own risk.",
-								);
+								f.appendText("Using this plugin is not recommended and may not work as expected. Use at your own risk.");
 								f.createEl("br");
-								f.appendText(
-									"Do you want to forcefully run it on mobile anyways?",
-								);
+								f.appendText("Do you want to forcefully run it on mobile anyways?");
 							}),
 						});
 						if (!confirmResult) {
@@ -594,8 +482,7 @@ export default class BetaPlugins {
 					rFiles.manifest = JSON.stringify(manifestObj);
 				}
 
-				if (this.plugin.settings.debuggingMode)
-					console.debug("BRAT: rFiles.manifest", usingBetaManifest, rFiles);
+				if (this.plugin.settings.debuggingMode) console.debug("BRAT: rFiles.manifest", usingBetaManifest, rFiles);
 
 				if (rFiles.mainJs === null) {
 					const msg = `${repositoryPath}\nThe release is not complete and cannot be downloaded. main.js is missing from the Release`;
@@ -609,10 +496,7 @@ export default class BetaPlugins {
 			if (!updatePluginFiles || forceReinstall) {
 				const releaseFiles = await getRelease();
 				if (releaseFiles === null) return false;
-				await this.writeReleaseFilesToPluginFolder(
-					primaryManifest.id,
-					releaseFiles,
-				);
+				await this.writeReleaseFilesToPluginFolder(primaryManifest.id, releaseFiles);
 				addBetaPluginToList(
 					this.plugin,
 					repositoryPath,
@@ -622,9 +506,7 @@ export default class BetaPlugins {
 				);
 				if (enableAfterInstall) {
 					const { plugins } = this.plugin.app;
-					const pluginTargetFolderPath = normalizePath(
-						`${plugins.getPluginFolder()}/${primaryManifest.id}`,
-					);
+					const pluginTargetFolderPath = normalizePath(`${plugins.getPluginFolder()}/${primaryManifest.id}`);
 					await plugins.loadManifest(pluginTargetFolderPath);
 					await plugins.enablePluginAndSave(primaryManifest.id);
 				}
@@ -639,12 +521,10 @@ export default class BetaPlugins {
 						noticeTimeout,
 					);
 				} else {
-					const versionText =
-						specifyVersion === "" ? "" : ` (version: ${specifyVersion})`;
+					const versionText = specifyVersion === "" ? "" : ` (version: ${specifyVersion})`;
 					let msg = `${repositoryPath}${versionText}\nThe plugin has been registered with BRAT.`;
 					if (!enableAfterInstall) {
-						msg +=
-							" You may still need to enable it the Community Plugin List.";
+						msg += " You may still need to enable it the Community Plugin List.";
 					}
 					await this.plugin.log(msg, true);
 					toastMessage(this.plugin, msg, noticeTimeout);
@@ -655,48 +535,24 @@ export default class BetaPlugins {
 				const pluginTargetFolderPath = `${this.plugin.app.vault.configDir}/plugins/${primaryManifest.id}/`;
 				let localManifestContents = "";
 				try {
-					localManifestContents = await this.plugin.app.vault.adapter.read(
-						`${pluginTargetFolderPath}manifest.json`,
-					);
+					localManifestContents = await this.plugin.app.vault.adapter.read(`${pluginTargetFolderPath}manifest.json`);
 				} catch (e) {
-					if (
-						(e as ErrnoType).errno === -4058 ||
-						(e as ErrnoType).errno === -2
-					) {
+					if ((e as ErrnoType).errno === -4058 || (e as ErrnoType).errno === -2) {
 						// file does not exist, try installing the plugin
-						await this.addPlugin(
-							repositoryPath,
-							false,
-							usingBetaManifest,
-							false,
-							specifyVersion,
-							false,
-							enableAfterInstall,
-							secretName,
-						);
+						await this.addPlugin(repositoryPath, false, usingBetaManifest, false, specifyVersion, false, enableAfterInstall, secretName);
 						// even though failed, return true since install will be attempted
 						return true;
 					}
-					console.error(
-						"BRAT - Local Manifest Load",
-						primaryManifest.id,
-						JSON.stringify(e, null, 2),
-					);
+					console.error("BRAT - Local Manifest Load", primaryManifest.id, JSON.stringify(e, null, 2));
 				}
 
 				if (specifyVersion !== "" && specifyVersion !== "latest") {
 					// skip the frozen version plugin
-					toastMessage(
-						this.plugin,
-						`The version of ${repositoryPath} is frozen, not updating.`,
-						3,
-					);
+					toastMessage(this.plugin, `The version of ${repositoryPath} is frozen, not updating.`, 3);
 					return false;
 				}
 
-				const localManifestJson = JSON.parse(
-					localManifestContents,
-				) as PluginManifest;
+				const localManifestJson = JSON.parse(localManifestContents) as PluginManifest;
 				// FIX for issue #105: Not all developers use semver compliant version tags
 				const localVersion = semverCoerce(localManifestJson.version, {
 					includePrerelease: true,
@@ -708,8 +564,7 @@ export default class BetaPlugins {
 				});
 				const hasNewerRemote =
 					localVersion && remoteVersion
-						? compareVersions(localVersion.version, remoteVersion.version) ===
-							-1
+						? compareVersions(localVersion.version, remoteVersion.version) === -1
 						: localManifestJson.version !== primaryManifest.version;
 
 				if (hasNewerRemote) {
@@ -726,40 +581,26 @@ export default class BetaPlugins {
 						);
 						toastMessage(this.plugin, msg, 30, () => {
 							if (primaryManifest) {
-								window.open(
-									`https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version}`,
-								);
+								window.open(`https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version}`);
 							}
 						});
 						return false;
 					}
-					await this.writeReleaseFilesToPluginFolder(
-						primaryManifest.id,
-						releaseFiles,
-					);
+					await this.writeReleaseFilesToPluginFolder(primaryManifest.id, releaseFiles);
 					await this.plugin.app.plugins.loadManifests();
 					await this.reloadPlugin(primaryManifest.id);
 					const msg = `${primaryManifest.id}\nPlugin has been updated from version ${localManifestJson.version} to ${primaryManifest.version}. `;
-					await this.plugin.log(
-						`${msg}[Release Info](https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version})`,
-						true,
-					);
+					await this.plugin.log(`${msg}[Release Info](https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version})`, true);
 					toastMessage(this.plugin, msg, 30, () => {
 						if (primaryManifest) {
-							window.open(
-								`https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version}`,
-							);
+							window.open(`https://github.com/${repositoryPath}/releases/tag/${primaryManifest.version}`);
 						}
 					});
 					return true;
 				}
 
 				if (reportIfNotUpdted) {
-					toastMessage(
-						this.plugin,
-						`No update available for ${repositoryPath}`,
-						3,
-					);
+					toastMessage(this.plugin, `No update available for ${repositoryPath}`, 3);
 				}
 				return true;
 			}
@@ -774,13 +615,9 @@ export default class BetaPlugins {
 			});
 
 			// Show user-friendly error message
-			const errorMessage =
-				error instanceof Error ? error.message : "Unknown error occurred";
+			const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 			// Log to BRAT's logging system
-			await this.plugin.log(
-				`Error ${updatePluginFiles ? "updating" : "adding"} plugin ${repositoryPath}: ${errorMessage}`,
-				true,
-			);
+			await this.plugin.log(`Error ${updatePluginFiles ? "updating" : "adding"} plugin ${repositoryPath}: ${errorMessage}`, true);
 
 			return false;
 		}
@@ -828,8 +665,7 @@ export default class BetaPlugins {
 			false,
 			secretName,
 		);
-		if (!result && !onlyCheckDontUpdate)
-			toastMessage(this.plugin, `${repositoryPath}\nUpdate of plugin failed.`);
+		if (!result && !onlyCheckDontUpdate) toastMessage(this.plugin, `${repositoryPath}\nUpdate of plugin failed.`);
 		return result;
 	}
 
@@ -839,10 +675,7 @@ export default class BetaPlugins {
 	 * @param showInfo - should this with a started/completed message - useful when ran from CP
 	 *
 	 */
-	async checkForPluginUpdatesAndInstallUpdates(
-		showInfo = false,
-		onlyCheckDontUpdate = false,
-	): Promise<void> {
+	async checkForPluginUpdatesAndInstallUpdates(showInfo = false, onlyCheckDontUpdate = false): Promise<void> {
 		if (!(await isConnectedToInternet())) {
 			console.debug("BRAT: No internet detected.");
 			return;
@@ -850,35 +683,18 @@ export default class BetaPlugins {
 		let newNotice: Notice | undefined;
 		const msg1 = "Checking for plugin updates STARTED";
 		await this.plugin.log(msg1, true);
-		if (showInfo && this.plugin.settings.notificationsEnabled)
-			newNotice = new Notice(`BRAT\n${msg1}`, 30000);
+		if (showInfo && this.plugin.settings.notificationsEnabled) newNotice = new Notice(`BRAT\n${msg1}`, 30000);
 		// Create a map of repo to version for frozen plugins
-		const frozenVersions = new Map(
-			this.plugin.settings.pluginSubListFrozenVersion.map((f) => [
-				f.repo,
-				f.version,
-			]),
-		);
+		const frozenVersions = new Map(this.plugin.settings.pluginSubListFrozenVersion.map((f) => [f.repo, f.version]));
 		// Create a map of repo to tokenName for per-repo tokens
-		const repoTokens = new Map(
-			this.plugin.settings.pluginSubListFrozenVersion.map((f) => [
-				f.repo,
-				f.tokenName || "",
-			]),
-		);
+		const repoTokens = new Map(this.plugin.settings.pluginSubListFrozenVersion.map((f) => [f.repo, f.tokenName || ""]));
 		for (const bp of this.plugin.settings.pluginList) {
 			// Skip if repo is frozen and not set to "latest"
 			const version = frozenVersions.get(bp);
 			if (version && version !== "latest") {
 				continue;
 			}
-			await this.updatePlugin(
-				bp,
-				onlyCheckDontUpdate,
-				false,
-				false,
-				repoTokens.get(bp) || "",
-			);
+			await this.updatePlugin(bp, onlyCheckDontUpdate, false, false, repoTokens.get(bp) || "");
 		}
 		const msg2 = "Checking for plugin updates COMPLETED";
 		await this.plugin.log(msg2, true);
@@ -899,13 +715,10 @@ export default class BetaPlugins {
 	deletePlugin(repositoryPath: string): void {
 		const msg = `Removed ${repositoryPath} from BRAT plugin list`;
 		void this.plugin.log(msg, true);
-		this.plugin.settings.pluginList = this.plugin.settings.pluginList.filter(
-			(b) => b !== repositoryPath,
+		this.plugin.settings.pluginList = this.plugin.settings.pluginList.filter((b) => b !== repositoryPath);
+		this.plugin.settings.pluginSubListFrozenVersion = this.plugin.settings.pluginSubListFrozenVersion.filter(
+			(b) => b.repo !== repositoryPath,
 		);
-		this.plugin.settings.pluginSubListFrozenVersion =
-			this.plugin.settings.pluginSubListFrozenVersion.filter(
-				(b) => b.repo !== repositoryPath,
-			);
 		void this.plugin.saveSettings();
 	}
 
@@ -919,27 +732,17 @@ export default class BetaPlugins {
 	getEnabledDisabledPlugins(enabled: boolean): PluginManifest[] {
 		const pl = this.plugin.app.plugins;
 		const manifests: PluginManifest[] = Object.values(pl.manifests);
-		const enabledPlugins: PluginManifest[] = Object.values(pl.plugins).map(
-			(p) => p.manifest,
-		);
+		const enabledPlugins: PluginManifest[] = Object.values(pl.plugins).map((p) => p.manifest);
 		return enabled
-			? manifests.filter((manifest) =>
-					enabledPlugins.find((pluginName) => manifest.id === pluginName.id),
-				)
-			: manifests.filter(
-					(manifest) =>
-						!enabledPlugins.find((pluginName) => manifest.id === pluginName.id),
-				);
+			? manifests.filter((manifest) => enabledPlugins.find((pluginName) => manifest.id === pluginName.id))
+			: manifests.filter((manifest) => !enabledPlugins.find((pluginName) => manifest.id === pluginName.id));
 	}
 
 	/**
 	 * Checks if there are any incompatible plugins installed and notifies the user
 	 */
 	checkIncompatiblePlugins(): void {
-		const incompatiblePluginIds =
-			this.plugin.settings.pluginSubListFrozenVersion
-				.filter((p) => p.isIncompatible)
-				.map((p) => p.repo);
+		const incompatiblePluginIds = this.plugin.settings.pluginSubListFrozenVersion.filter((p) => p.isIncompatible).map((p) => p.repo);
 		if (incompatiblePluginIds.length > 0) {
 			toastMessage(
 				this.plugin,

--- a/src/features/themes.ts
+++ b/src/features/themes.ts
@@ -1,18 +1,11 @@
 import type { ThemeManifest } from "@obsidian-typings/obsidian-public-1.11.4";
 import { Notice, normalizePath } from "obsidian";
+import { getTranslations } from "../i18n";
 import type BratPlugin from "../main";
-import {
-	addBetaThemeToList,
-	updateBetaThemeLastUpdateChecksum,
-} from "../settings";
+import { addBetaThemeToList, updateBetaThemeLastUpdateChecksum } from "../settings";
 import { isConnectedToInternet } from "../utils/internetconnection";
 import { toastMessage } from "../utils/notifications";
-import {
-	checksumForString,
-	grabChecksumOfThemeCssFile,
-	grabCommmunityThemeCssFile,
-	grabCommmunityThemeManifestFile,
-} from "./githubUtils";
+import { checksumForString, grabChecksumOfThemeCssFile, grabCommmunityThemeCssFile, grabCommmunityThemeManifestFile } from "./githubUtils";
 
 /**
  * Installs or updates a theme
@@ -23,86 +16,49 @@ import {
  *
  * @returns true for succcess
  */
-export const themeSave = async (
-	plugin: BratPlugin,
-	cssGithubRepository: string,
-	newInstall: boolean,
-): Promise<boolean> => {
+export const themeSave = async (plugin: BratPlugin, cssGithubRepository: string, newInstall: boolean): Promise<boolean> => {
+	const text = getTranslations().themeMessages;
 	// test for themes-beta.css
-	let themeCss = await grabCommmunityThemeCssFile(
-		cssGithubRepository,
-		true,
-		plugin.settings.debuggingMode,
-	);
+	let themeCss = await grabCommmunityThemeCssFile(cssGithubRepository, true, plugin.settings.debuggingMode);
 	// grabe themes.css if no beta
-	if (!themeCss)
-		themeCss = await grabCommmunityThemeCssFile(
-			cssGithubRepository,
-			false,
-			plugin.settings.debuggingMode,
-		);
+	if (!themeCss) themeCss = await grabCommmunityThemeCssFile(cssGithubRepository, false, plugin.settings.debuggingMode);
 
 	if (!themeCss) {
-		toastMessage(
-			plugin,
-			"There is no theme.css or theme-beta.css file in the root path of this repository, so there is no theme to install.",
-		);
+		toastMessage(plugin, text.noThemeCssFile);
 		return false;
 	}
 
-	const themeManifest = await grabCommmunityThemeManifestFile(
-		cssGithubRepository,
-		plugin.settings.debuggingMode,
-	);
+	const themeManifest = await grabCommmunityThemeManifestFile(cssGithubRepository, plugin.settings.debuggingMode);
 	if (!themeManifest) {
-		toastMessage(
-			plugin,
-			"There is no manifest.json file in the root path of this repository, so theme cannot be installed.",
-		);
+		toastMessage(plugin, text.noManifestFile);
 		return false;
 	}
 
 	const manifestInfo = (await JSON.parse(themeManifest)) as ThemeManifest;
 
-	const themeTargetFolderPath = normalizePath(
-		themesRootPath(plugin) + manifestInfo.name,
-	);
+	const themeTargetFolderPath = normalizePath(themesRootPath(plugin) + manifestInfo.name);
 
 	const { adapter } = plugin.app.vault;
-	if (!(await adapter.exists(themeTargetFolderPath)))
-		await adapter.mkdir(themeTargetFolderPath);
+	if (!(await adapter.exists(themeTargetFolderPath))) await adapter.mkdir(themeTargetFolderPath);
 
-	await adapter.write(
-		normalizePath(`${themeTargetFolderPath}/theme.css`),
-		themeCss,
-	);
-	await adapter.write(
-		normalizePath(`${themeTargetFolderPath}/manifest.json`),
-		themeManifest,
-	);
+	await adapter.write(normalizePath(`${themeTargetFolderPath}/theme.css`), themeCss);
+	await adapter.write(normalizePath(`${themeTargetFolderPath}/manifest.json`), themeManifest);
 
-	updateBetaThemeLastUpdateChecksum(
-		plugin,
-		cssGithubRepository,
-		checksumForString(themeCss),
-	);
+	updateBetaThemeLastUpdateChecksum(plugin, cssGithubRepository, checksumForString(themeCss));
 
 	let msg = "";
 
 	if (newInstall) {
 		addBetaThemeToList(plugin, cssGithubRepository, themeCss);
-		msg = `${manifestInfo.name} theme installed from ${cssGithubRepository}. `;
+		msg = text.installed(manifestInfo.name, cssGithubRepository);
 		window.setTimeout(() => {
 			plugin.app.customCss.setTheme(manifestInfo.name);
 		}, 500);
 	} else {
-		msg = `${manifestInfo.name} theme updated from ${cssGithubRepository}.`;
+		msg = text.updated(manifestInfo.name, cssGithubRepository);
 	}
 
-	void plugin.log(
-		`${msg}[Theme Info](https://github.com/${cssGithubRepository})`,
-		false,
-	);
+	void plugin.log(`${msg}[Theme Info](https://github.com/${cssGithubRepository})`, false);
 	toastMessage(plugin, msg, 20, (): void => {
 		window.open(`https://github.com/${cssGithubRepository}`);
 	});
@@ -116,10 +72,7 @@ export const themeSave = async (
  * @param showInfo - provide  notices during the update proces
  *
  */
-export const themesCheckAndUpdates = async (
-	plugin: BratPlugin,
-	showInfo: boolean,
-): Promise<void> => {
+export const themesCheckAndUpdates = async (plugin: BratPlugin, showInfo: boolean): Promise<void> => {
 	if (!(await isConnectedToInternet())) {
 		console.debug("BRAT: No internet detected.");
 		return;
@@ -127,25 +80,14 @@ export const themesCheckAndUpdates = async (
 	let newNotice: Notice | undefined;
 	const msg1 = "Checking for beta theme updates STARTED";
 	await plugin.log(msg1, true);
-	if (showInfo && plugin.settings.notificationsEnabled)
-		newNotice = new Notice(`BRAT\n${msg1}`, 30000);
+	if (showInfo && plugin.settings.notificationsEnabled) newNotice = new Notice(`BRAT\n${msg1}`, 30000);
 	for (const t of plugin.settings.themesList) {
 		// first test to see if theme-beta.css exists
-		let lastUpdateOnline = await grabChecksumOfThemeCssFile(
-			t.repo,
-			true,
-			plugin.settings.debuggingMode,
-		);
+		let lastUpdateOnline = await grabChecksumOfThemeCssFile(t.repo, true, plugin.settings.debuggingMode);
 		// if theme-beta.css does NOT exist, try to get theme.css
-		if (lastUpdateOnline === "0")
-			lastUpdateOnline = await grabChecksumOfThemeCssFile(
-				t.repo,
-				false,
-				plugin.settings.debuggingMode,
-			);
+		if (lastUpdateOnline === "0") lastUpdateOnline = await grabChecksumOfThemeCssFile(t.repo, false, plugin.settings.debuggingMode);
 		console.debug("BRAT: lastUpdateOnline", lastUpdateOnline);
-		if (lastUpdateOnline !== t.lastUpdate)
-			await themeSave(plugin, t.repo, false);
+		if (lastUpdateOnline !== t.lastUpdate) await themeSave(plugin, t.repo, false);
 	}
 	const msg2 = "Checking for beta theme updates COMPLETED";
 	await plugin.log(msg2, true);
@@ -162,15 +104,11 @@ export const themesCheckAndUpdates = async (
  * @param cssGithubRepository - Repository path
  *
  */
-export const themeDelete = (
-	plugin: BratPlugin,
-	cssGithubRepository: string,
-): void => {
-	plugin.settings.themesList = plugin.settings.themesList.filter(
-		(t) => t.repo !== cssGithubRepository,
-	);
+export const themeDelete = (plugin: BratPlugin, cssGithubRepository: string): void => {
+	const text = getTranslations().themeMessages;
+	plugin.settings.themesList = plugin.settings.themesList.filter((t) => t.repo !== cssGithubRepository);
 	void plugin.saveSettings();
-	const msg = `Removed ${cssGithubRepository} from BRAT themes list and will no longer be updated. However, the theme files still exist in the vault. To remove them, go into Settings > Appearance and remove the theme.`;
+	const msg = text.removed(cssGithubRepository);
 	void plugin.log(msg, true);
 	toastMessage(plugin, msg);
 };

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -62,8 +62,7 @@ export const de = {
 					prependText:
 						"Lege ein persönliches Zugriffstoken fest, um die Rate Limits für öffentliche GitHub-Repositorys zu erhöhen. Du kannst es in ",
 					linkText: "deinen GitHub-Kontoeinstellungen",
-					appendText:
-						" erstellen und anschließend hier hinzufügen. Weitere Informationen findest du in der Dokumentation.",
+					appendText: " erstellen und anschließend hier hinzufügen. Weitere Informationen findest du in der Dokumentation.",
 				},
 			},
 			clearPersonalAccessToken: "Persönliches Zugriffstoken löschen",
@@ -85,15 +84,13 @@ export const de = {
 			trackedVersion: (version: string, frozen: boolean): string =>
 				` Verfolgte Version: ${version === "latest" ? "neueste Version" : version} ${frozen ? "(fixiert)" : ""}`,
 			incompatible: " (inkompatibel)",
-			secretMissing: (secretName: string): string =>
-				` Secret nicht definiert oder leer: ${secretName}`,
+			secretMissing: (secretName: string): string => ` Secret nicht definiert oder leer: ${secretName}`,
 			secretMissingTitle:
 				"Ein Token-Name ist konfiguriert, aber das Secret fehlt. Füge das Secret hinzu oder aktualisiere die Plugin-Konfiguration.",
 			secretMissingTooltip: (secretName: string): string =>
 				`Secret fehlt: ${secretName}. Bitte füge das Secret hinzu oder aktualisiere die Plugin-Konfiguration.`,
 			checkAndUpdatePlugin: "Plugin prüfen und aktualisieren",
-			changeVersionAndUpdateSettings:
-				"Version ändern und Einstellungen aktualisieren",
+			changeVersionAndUpdateSettings: "Version ändern und Einstellungen aktualisieren",
 			removeThisBetaPlugin: "Dieses Beta-Plugin entfernen",
 			confirmRemoval: "Zum Bestätigen erneut klicken",
 			copyPluginIdentifier: "Plugin-Kennung kopieren",
@@ -108,8 +105,7 @@ export const de = {
 		},
 		copyIdentifier: {
 			copied: (identifier: string): string => `Kopiert: ${identifier}`,
-			failed:
-				"Kennung konnte nicht kopiert werden. Bitte prüfe die Clipboard-Berechtigungen.",
+			failed: "Kennung konnte nicht kopiert werden. Bitte prüfe die Clipboard-Berechtigungen.",
 		},
 	},
 	addBetaPluginModal: {
@@ -127,21 +123,15 @@ export const de = {
 		},
 		repository: {
 			label: "Repository",
-			placeholder:
-				"Repository (Beispiel: https://GitHub.com/githubusername/repository-name)",
-			enterAddressToValidate:
-				"Gib eine GitHub-Repository-Adresse ein, um sie zu validieren.",
+			placeholder: "Repository (Beispiel: https://GitHub.com/githubusername/repository-name)",
+			enterAddressToValidate: "Gib eine GitHub-Repository-Adresse ein, um sie zu validieren.",
 			addressRequired: "Repository-Adresse ist erforderlich.",
 			validating: "Repository-Adresse wird validiert...",
-			noReleasesFound:
-				"Fehler: In diesem Repository wurden keine Releases gefunden.",
-			notFound:
-				"Repository nicht gefunden. Prüfe die Adresse oder gib ein gültiges Token für den Zugriff auf ein privates Repository an.",
-			accessDenied:
-				"Zugriff verweigert. Prüfe dein persönliches Zugriffstoken.",
+			noReleasesFound: "Fehler: In diesem Repository wurden keine Releases gefunden.",
+			notFound: "Repository nicht gefunden. Prüfe die Adresse oder gib ein gültiges Token für den Zugriff auf ein privates Repository an.",
+			accessDenied: "Zugriff verweigert. Prüfe dein persönliches Zugriffstoken.",
 			error: (message: string): string => `Fehler: ${message}`,
-			rateLimitExceeded: (minutes: number): string =>
-				`GitHub API Rate Limit überschritten. Versuche es in ${minutes} Minuten erneut.`,
+			rateLimitExceeded: (minutes: number): string => `GitHub API Rate Limit überschritten. Versuche es in ${minutes} Minuten erneut.`,
 			rateLimitToast: (message: string): string =>
 				`${message} Du kannst in den BRAT-Einstellungen ein persönliches Zugriffstoken hinzufügen, um höhere Limits zu erhalten. Siehe Dokumentation für Details.`,
 			gitHubResponseToast: (message: string): string => `${message} `,
@@ -155,20 +145,32 @@ export const de = {
 		token: {
 			name: "GitHub-Token",
 			desc: "Wähle ein Secret als Token für dieses Repository aus (optional)",
-			settingCleared: (repository: string): string =>
-				`Token-Einstellung für ${repository} gelöscht`,
-			settingUpdated: (repository: string): string =>
-				`Token-Einstellung für ${repository} aktualisiert`,
+			settingCleared: (repository: string): string => `Token-Einstellung für ${repository} gelöscht`,
+			settingUpdated: (repository: string): string => `Token-Einstellung für ${repository} aktualisiert`,
 		},
 		enableAfterInstall: "Plugin nach der Installation aktivieren",
 		alreadyInList: "Dieses Plugin ist bereits in der Beta-Testliste",
 	},
+	addBetaThemeModal: {
+		heading: {
+			githubRepositoryForBetaTheme: "GitHub-Repository für das Beta-Theme:",
+		},
+		alreadyInList: "Dieses Theme ist bereits in der Beta-Testliste",
+	},
+	themeMessages: {
+		noThemeCssFile:
+			"Im Stammverzeichnis dieses Repositorys gibt es keine Datei theme.css oder theme-beta.css, daher kann kein Theme installiert werden.",
+		noManifestFile:
+			"Im Stammverzeichnis dieses Repositorys gibt es keine Datei manifest.json, daher kann das Theme nicht installiert werden.",
+		installed: (themeName: string, repository: string): string => `Theme ${themeName} wurde aus ${repository} installiert. `,
+		updated: (themeName: string, repository: string): string => `Theme ${themeName} wurde aus ${repository} aktualisiert.`,
+		removed: (repository: string): string =>
+			`${repository} wurde aus der BRAT-Theme-Liste entfernt und wird nicht mehr aktualisiert. Die Theme-Dateien sind jedoch weiterhin im Vault vorhanden. Um sie zu entfernen, öffne Einstellungen > Erscheinungsbild und entferne das Theme dort.`,
+	},
 	versionSuggestModal: {
 		title: "Version auswählen",
-		placeholder: (repository: string): string =>
-			`Version für ${repository} suchen`,
-		versionLabel: (version: string): string =>
-			version === "latest" ? "Neueste Version" : version,
+		placeholder: (repository: string): string => `Version für ${repository} suchen`,
+		versionLabel: (version: string): string => (version === "latest" ? "Neueste Version" : version),
 		instructions: {
 			navigateVersions: "Versionen durchsuchen",
 			selectVersion: "Version auswählen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -57,11 +57,9 @@ export const en = {
 			personalAccessToken: {
 				name: "Personal access token",
 				desc: {
-					prependText:
-						"Set a personal access token to increase rate limits for public repositories on GitHub. You can create one in ",
+					prependText: "Set a personal access token to increase rate limits for public repositories on GitHub. You can create one in ",
 					linkText: "your GitHub account settings",
-					appendText:
-						" and then add it here. Please consult the documentation for more details.",
+					appendText: " and then add it here. Please consult the documentation for more details.",
 				},
 			},
 			clearPersonalAccessToken: "Clear personal access token",
@@ -76,17 +74,13 @@ export const en = {
 				editAndRemove:
 					'Click the "edit" button next to a plugin to change the installed version. Click the "X" button next to a plugin to remove it from the list.',
 				noteLabel: "Note: ",
-				noteText:
-					"Removing from the list does not delete the plugin, this should be done from the Community Plugins tab in Settings.",
+				noteText: "Removing from the list does not delete the plugin, this should be done from the Community Plugins tab in Settings.",
 			},
 			addBetaPlugin: "Add beta plugin",
-			trackedVersion: (version: string, frozen: boolean): string =>
-				` Tracked version: ${version} ${frozen ? "(frozen)" : ""}`,
+			trackedVersion: (version: string, frozen: boolean): string => ` Tracked version: ${version} ${frozen ? "(frozen)" : ""}`,
 			incompatible: " (incompatible)",
-			secretMissing: (secretName: string): string =>
-				` Secret not defined or empty: ${secretName}`,
-			secretMissingTitle:
-				"Token name configured but secret is missing. Add the secret or update the plugin configuration.",
+			secretMissing: (secretName: string): string => ` Secret not defined or empty: ${secretName}`,
+			secretMissingTitle: "Token name configured but secret is missing. Add the secret or update the plugin configuration.",
 			secretMissingTooltip: (secretName: string): string =>
 				`Secret missing: ${secretName}. Please add the secret or update the plugin configuration.`,
 			checkAndUpdatePlugin: "Check and update plugin",
@@ -123,19 +117,15 @@ export const en = {
 		},
 		repository: {
 			label: "Repository",
-			placeholder:
-				"Repository (example: https://GitHub.com/githubusername/repository-name)",
-			enterAddressToValidate:
-				"Enter a GitHub repository address to validate it.",
+			placeholder: "Repository (example: https://GitHub.com/githubusername/repository-name)",
+			enterAddressToValidate: "Enter a GitHub repository address to validate it.",
 			addressRequired: "Repository address is required.",
 			validating: "Validating repository address...",
 			noReleasesFound: "Error: No releases found in this repository.",
-			notFound:
-				"Repository not found. Check the address or provide a valid token for access to a private repository.",
+			notFound: "Repository not found. Check the address or provide a valid token for access to a private repository.",
 			accessDenied: "Access denied. Check your personal access token.",
 			error: (message: string): string => `Error: ${message}`,
-			rateLimitExceeded: (minutes: number): string =>
-				`GitHub API rate limit exceeded. Try again in ${minutes} minutes.`,
+			rateLimitExceeded: (minutes: number): string => `GitHub API rate limit exceeded. Try again in ${minutes} minutes.`,
 			rateLimitToast: (message: string): string =>
 				`${message} Consider adding a personal access token in BRAT settings for higher limits. See documentation for details.`,
 			gitHubResponseToast: (message: string): string => `${message} `,
@@ -149,18 +139,29 @@ export const en = {
 		token: {
 			name: "GitHub token",
 			desc: "Select a secret as token for this repository (optional)",
-			settingCleared: (repository: string): string =>
-				`Token setting cleared for ${repository}`,
-			settingUpdated: (repository: string): string =>
-				`Token setting updated for ${repository}`,
+			settingCleared: (repository: string): string => `Token setting cleared for ${repository}`,
+			settingUpdated: (repository: string): string => `Token setting updated for ${repository}`,
 		},
 		enableAfterInstall: "Enable after installing the plugin",
 		alreadyInList: "This plugin is already in the list for beta testing",
 	},
+	addBetaThemeModal: {
+		heading: {
+			githubRepositoryForBetaTheme: "GitHub repository for beta theme:",
+		},
+		alreadyInList: "This theme is already in the list for beta testing",
+	},
+	themeMessages: {
+		noThemeCssFile: "There is no theme.css or theme-beta.css file in the root path of this repository, so there is no theme to install.",
+		noManifestFile: "There is no manifest.json file in the root path of this repository, so theme cannot be installed.",
+		installed: (themeName: string, repository: string): string => `${themeName} theme installed from ${repository}. `,
+		updated: (themeName: string, repository: string): string => `${themeName} theme updated from ${repository}.`,
+		removed: (repository: string): string =>
+			`Removed ${repository} from BRAT themes list and will no longer be updated. However, the theme files still exist in the vault. To remove them, go into Settings > Appearance and remove the theme.`,
+	},
 	versionSuggestModal: {
 		title: "Select a version",
-		placeholder: (repository: string): string =>
-			`Type to search for a version for ${repository}`,
+		placeholder: (repository: string): string => `Type to search for a version for ${repository}`,
 		versionLabel: (version: string): string => version,
 		instructions: {
 			navigateVersions: "Navigate versions",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -59,11 +59,9 @@ export const ja = {
 			personalAccessToken: {
 				name: "個人アクセストークン",
 				desc: {
-					prependText:
-						"個人アクセストークンを設定すると、GitHub の公開リポジトリに対するレート制限を緩和できます。トークンは ",
+					prependText: "個人アクセストークンを設定すると、GitHub の公開リポジトリに対するレート制限を緩和できます。トークンは ",
 					linkText: "GitHub アカウント設定",
-					appendText:
-						" で作成し、ここに追加できます。詳しくはドキュメントを参照してください。",
+					appendText: " で作成し、ここに追加できます。詳しくはドキュメントを参照してください。",
 				},
 			},
 			clearPersonalAccessToken: "個人アクセストークンをクリア",
@@ -78,15 +76,13 @@ export const ja = {
 				editAndRemove:
 					"プラグイン横の「編集」ボタンをクリックすると、インストールするバージョンを変更できます。プラグイン横の「X」ボタンをクリックすると、一覧から削除できます。",
 				noteLabel: "注意：",
-				noteText:
-					"一覧から削除してもプラグイン本体は削除されません。削除するには、設定のコミュニティプラグインタブから操作してください。",
+				noteText: "一覧から削除してもプラグイン本体は削除されません。削除するには、設定のコミュニティプラグインタブから操作してください。",
 			},
 			addBetaPlugin: "Beta プラグインを追加",
 			trackedVersion: (version: string, frozen: boolean): string =>
 				` 追跡中のバージョン：${version === "latest" ? "最新バージョン" : version}${frozen ? "（固定）" : ""}`,
 			incompatible: "（互換性なし）",
-			secretMissing: (secretName: string): string =>
-				` シークレットが未定義または空です：${secretName}`,
+			secretMissing: (secretName: string): string => ` シークレットが未定義または空です：${secretName}`,
 			secretMissingTitle:
 				"トークン名は設定されていますが、シークレットが見つからないか空です。シークレットを追加するか、プラグイン設定を更新してください。",
 			secretMissingTooltip: (secretName: string): string =>
@@ -107,8 +103,7 @@ export const ja = {
 		},
 		copyIdentifier: {
 			copied: (identifier: string): string => `コピーしました：${identifier}`,
-			failed:
-				"識別子のコピーに失敗しました。クリップボードの権限を確認してください。",
+			failed: "識別子のコピーに失敗しました。クリップボードの権限を確認してください。",
 		},
 	},
 	addBetaPluginModal: {
@@ -126,20 +121,16 @@ export const ja = {
 		},
 		repository: {
 			label: "リポジトリ",
-			placeholder:
-				"リポジトリ（例：https://GitHub.com/githubusername/repository-name）",
-			enterAddressToValidate:
-				"検証する GitHub リポジトリアドレスを入力してください。",
+			placeholder: "リポジトリ（例：https://GitHub.com/githubusername/repository-name）",
+			enterAddressToValidate: "検証する GitHub リポジトリアドレスを入力してください。",
 			addressRequired: "リポジトリアドレスが必要です。",
 			validating: "リポジトリアドレスを検証中...",
 			noReleasesFound: "エラー：このリポジトリにリリースが見つかりません。",
 			notFound:
 				"リポジトリが見つかりません。アドレスを確認するか、プライベートリポジトリにアクセスできる有効なトークンを指定してください。",
-			accessDenied:
-				"アクセスが拒否されました。個人アクセストークンを確認してください。",
+			accessDenied: "アクセスが拒否されました。個人アクセストークンを確認してください。",
 			error: (message: string): string => `エラー：${message}`,
-			rateLimitExceeded: (minutes: number): string =>
-				`GitHub API のレート制限を超過しました。${minutes} 分後にもう一度お試しください。`,
+			rateLimitExceeded: (minutes: number): string => `GitHub API のレート制限を超過しました。${minutes} 分後にもう一度お試しください。`,
 			rateLimitToast: (message: string): string =>
 				`${message} BRAT 設定で個人アクセストークンを追加すると、より高い制限を利用できます。詳しくはドキュメントを参照してください。`,
 			gitHubResponseToast: (message: string): string => `${message} `,
@@ -153,20 +144,30 @@ export const ja = {
 		token: {
 			name: "GitHub トークン",
 			desc: "このリポジトリ用のトークンとして使用するシークレットを選択します（任意）",
-			settingCleared: (repository: string): string =>
-				`${repository} のトークン設定をクリアしました`,
-			settingUpdated: (repository: string): string =>
-				`${repository} のトークン設定を更新しました`,
+			settingCleared: (repository: string): string => `${repository} のトークン設定をクリアしました`,
+			settingUpdated: (repository: string): string => `${repository} のトークン設定を更新しました`,
 		},
 		enableAfterInstall: "インストール後にプラグインを有効化",
 		alreadyInList: "このプラグインはすでに Beta テスト一覧にあります",
 	},
+	addBetaThemeModal: {
+		heading: {
+			githubRepositoryForBetaTheme: "Beta テーマの GitHub リポジトリ：",
+		},
+		alreadyInList: "このテーマはすでに Beta テスト一覧にあります",
+	},
+	themeMessages: {
+		noThemeCssFile: "このリポジトリのルートパスには theme.css または theme-beta.css がないため、インストールできるテーマがありません。",
+		noManifestFile: "このリポジトリのルートパスには manifest.json がないため、テーマをインストールできません。",
+		installed: (themeName: string, repository: string): string => `${repository} からテーマ ${themeName} をインストールしました。`,
+		updated: (themeName: string, repository: string): string => `${repository} からテーマ ${themeName} を更新しました。`,
+		removed: (repository: string): string =>
+			`${repository} を BRAT のテーマ一覧から削除したため、今後は更新されません。ただし、テーマファイル自体は Vault に残ります。削除するには、設定 > 外観 からテーマを削除してください。`,
+	},
 	versionSuggestModal: {
 		title: "バージョンを選択",
-		placeholder: (repository: string): string =>
-			`${repository} のバージョンを検索`,
-		versionLabel: (version: string): string =>
-			version === "latest" ? "最新バージョン" : version,
+		placeholder: (repository: string): string => `${repository} のバージョンを検索`,
+		versionLabel: (version: string): string => (version === "latest" ? "最新バージョン" : version),
 		instructions: {
 			navigateVersions: "バージョンを移動",
 			selectVersion: "バージョンを選択",

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -59,11 +59,9 @@ export const zhCn = {
 			personalAccessToken: {
 				name: "个人访问令牌",
 				desc: {
-					prependText:
-						"设置个人访问令牌可以提高访问 GitHub 公共仓库时的请求额度。你可以在 ",
+					prependText: "设置个人访问令牌可以提高访问 GitHub 公共仓库时的请求额度。你可以在 ",
 					linkText: "GitHub 令牌设置",
-					appendText:
-						" 中创建令牌，然后在这里选择保存该令牌的密钥。更多信息请参考文档。",
+					appendText: " 中创建令牌，然后在这里选择保存该令牌的密钥。更多信息请参考文档。",
 				},
 			},
 			clearPersonalAccessToken: "清除个人访问令牌设置",
@@ -75,22 +73,17 @@ export const zhCn = {
 			description: {
 				intro:
 					"下方列出已通过 BRAT 添加的 Beta 插件。你可以让插件跟随最新版本，也可以固定到某个发布版本。固定版本指基于 release 标签指定的某个插件版本。",
-				editAndRemove:
-					"点击插件旁的编辑按钮可以更改安装版本；点击 X 按钮会将它从列表中移除。",
+				editAndRemove: "点击插件旁的编辑按钮可以更改安装版本；点击 X 按钮会将它从列表中移除。",
 				noteLabel: "注意：",
-				noteText:
-					"从列表中移除不会删除插件本体。如需删除插件，请到设置中的“第三方插件”页面操作。",
+				noteText: "从列表中移除不会删除插件本体。如需删除插件，请到设置中的“第三方插件”页面操作。",
 			},
 			addBetaPlugin: "添加 Beta 插件",
 			trackedVersion: (version: string, frozen: boolean): string =>
 				`跟踪版本：${version === "latest" ? "最新版本" : version}${frozen ? "（固定）" : ""}`,
 			incompatible: "（不兼容）",
-			secretMissing: (secretName: string): string =>
-				`密钥未定义或为空：${secretName}`,
-			secretMissingTitle:
-				"已配置密钥名称，但密钥不存在或为空。请添加密钥，或更新该插件配置。",
-			secretMissingTooltip: (secretName: string): string =>
-				`密钥缺失：${secretName}。请添加密钥，或更新该插件配置。`,
+			secretMissing: (secretName: string): string => `密钥未定义或为空：${secretName}`,
+			secretMissingTitle: "已配置密钥名称，但密钥不存在或为空。请添加密钥，或更新该插件配置。",
+			secretMissingTooltip: (secretName: string): string => `密钥缺失：${secretName}。请添加密钥，或更新该插件配置。`,
 			checkAndUpdatePlugin: "检查并更新插件",
 			changeVersionAndUpdateSettings: "更改版本和设置",
 			removeThisBetaPlugin: "移除此 Beta 插件",
@@ -125,8 +118,7 @@ export const zhCn = {
 		},
 		repository: {
 			label: "仓库",
-			placeholder:
-				"仓库（示例：https://GitHub.com/githubusername/repository-name）",
+			placeholder: "仓库（示例：https://GitHub.com/githubusername/repository-name）",
 			enterAddressToValidate: "输入 GitHub 仓库地址后会自动验证。",
 			addressRequired: "需要填写仓库地址。",
 			validating: "正在验证仓库地址...",
@@ -134,10 +126,8 @@ export const zhCn = {
 			notFound: "找不到仓库。请检查地址，或提供可访问私有仓库的有效令牌。",
 			accessDenied: "访问被拒绝。请检查个人访问令牌。",
 			error: (message: string): string => `错误：${message}`,
-			rateLimitExceeded: (minutes: number): string =>
-				`GitHub API 请求额度已用尽。请在 ${minutes} 分钟后重试。`,
-			rateLimitToast: (): string =>
-				"GitHub API 请求额度已用尽。可以在 BRAT 设置中添加个人访问令牌以提高额度。详情请查看文档。",
+			rateLimitExceeded: (minutes: number): string => `GitHub API 请求额度已用尽。请在 ${minutes} 分钟后重试。`,
+			rateLimitToast: (): string => "GitHub API 请求额度已用尽。可以在 BRAT 设置中添加个人访问令牌以提高额度。详情请查看文档。",
 			gitHubResponseToast: (message: string): string => `${message} `,
 		},
 		version: {
@@ -149,20 +139,30 @@ export const zhCn = {
 		token: {
 			name: "GitHub 令牌",
 			desc: "选择一个密钥，作为访问此仓库的令牌（可选）",
-			settingCleared: (repository: string): string =>
-				`已清除 ${repository} 的令牌设置`,
-			settingUpdated: (repository: string): string =>
-				`已更新 ${repository} 的令牌设置`,
+			settingCleared: (repository: string): string => `已清除 ${repository} 的令牌设置`,
+			settingUpdated: (repository: string): string => `已更新 ${repository} 的令牌设置`,
 		},
 		enableAfterInstall: "安装后启用此插件",
 		alreadyInList: "这个插件已经在 Beta 测试列表中",
 	},
+	addBetaThemeModal: {
+		heading: {
+			githubRepositoryForBetaTheme: "Beta 主题的 GitHub 仓库：",
+		},
+		alreadyInList: "这个主题已经在 Beta 测试列表中",
+	},
+	themeMessages: {
+		noThemeCssFile: "这个仓库的根目录里没有 theme.css 或 theme-beta.css 文件，因此没有可安装的主题。",
+		noManifestFile: "这个仓库的根目录里没有 manifest.json 文件，因此无法安装该主题。",
+		installed: (themeName: string, repository: string): string => `已从 ${repository} 安装主题 ${themeName}。`,
+		updated: (themeName: string, repository: string): string => `已从 ${repository} 更新主题 ${themeName}。`,
+		removed: (repository: string): string =>
+			`已将 ${repository} 从 BRAT 主题列表中移除，之后不会再检查更新。不过主题文件仍然保留在库中。如需删除，请前往“设置 > 外观”中移除该主题。`,
+	},
 	versionSuggestModal: {
 		title: "选择版本",
-		placeholder: (repository: string): string =>
-			`输入关键词，搜索 ${repository} 的版本`,
-		versionLabel: (version: string): string =>
-			version === "latest" ? "最新版本" : version,
+		placeholder: (repository: string): string => `输入关键词，搜索 ${repository} 的版本`,
+		versionLabel: (version: string): string => (version === "latest" ? "最新版本" : version),
 		instructions: {
 			navigateVersions: "浏览版本",
 			selectVersion: "选择版本",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,8 +1,181 @@
-import type {} from "@obsidian-typings/obsidian-public-1.11.4";
-import type BratApi from "./utils/BratAPI";
+/// <reference types="@obsidian-typings/obsidian-public-1.11.4" />
+
+import type BratAPI from "./utils/BratAPI";
+export {};
 
 declare global {
 	interface Window {
-		bratAPI?: BratApi;
+		bratAPI?: BratAPI;
+	}
+}
+
+declare module "obsidian" {
+	export interface SettingControlBase<V, K extends string = string> {
+		key: K;
+		defaultValue?: V;
+		validate?: (value: V) => string | void | Promise<string | void>;
+		disabled?: boolean | (() => boolean);
+	}
+
+	export interface SettingToggleControl<K extends string = string> extends SettingControlBase<boolean, K> {
+		type: "toggle";
+	}
+
+	export interface SettingTextControl<K extends string = string> extends SettingControlBase<string, K> {
+		type: "text";
+		placeholder?: string;
+	}
+
+	export interface SettingTextAreaControl<K extends string = string> extends SettingControlBase<string, K> {
+		type: "textarea";
+		placeholder?: string;
+		rows?: number;
+	}
+
+	export interface SettingNumberControl<K extends string = string> extends SettingControlBase<number, K> {
+		type: "number";
+		min?: number;
+		max?: number;
+		step?: number;
+		placeholder?: string;
+	}
+
+	export interface SettingSliderControl<K extends string = string> extends SettingControlBase<number, K> {
+		type: "slider";
+		min: number;
+		max: number;
+		step: number;
+	}
+
+	export interface SettingDropdownControl<K extends string = string> extends SettingControlBase<string, K> {
+		type: "dropdown";
+		options: Record<string, string>;
+	}
+
+	export interface SettingFileControl<K extends string = string> extends SettingControlBase<string, K> {
+		type: "file";
+		placeholder?: string;
+		filter?: (file: import("obsidian").TFile) => boolean;
+	}
+
+	export interface SettingFolderControl<K extends string = string> extends SettingControlBase<string, K> {
+		type: "folder";
+		includeRoot?: boolean;
+		placeholder?: string;
+		filter?: (folder: import("obsidian").TFolder) => boolean;
+	}
+
+	export interface SettingColorControl<K extends string = string> extends SettingControlBase<string, K> {
+		type: "color";
+	}
+
+	export type SettingControl<K extends string = string> =
+		| SettingToggleControl<K>
+		| SettingDropdownControl<K>
+		| SettingTextControl<K>
+		| SettingTextAreaControl<K>
+		| SettingNumberControl<K>
+		| SettingFileControl<K>
+		| SettingFolderControl<K>
+		| SettingSliderControl<K>
+		| SettingColorControl<K>;
+
+	export interface SettingDefinitionBase {
+		name: string;
+		desc?: string | DocumentFragment;
+		aliases?: string[];
+		searchable?: boolean | (() => boolean);
+		visible?: boolean | (() => boolean);
+	}
+
+	export interface SettingDefinitionControl<K extends string = string> extends SettingDefinitionBase {
+		control: SettingControl<K>;
+		action?: never;
+		render?: never;
+	}
+
+	export interface SettingDefinitionEmpty extends SettingDefinitionBase {
+		control?: never;
+		action?: never;
+		render?: never;
+	}
+
+	export interface SettingDefinitionAction extends SettingDefinitionBase {
+		action: (el: HTMLElement, index: number) => void;
+		disabled?: boolean | (() => boolean);
+		control?: never;
+		render?: never;
+	}
+
+	export interface SettingDefinitionRender extends SettingDefinitionBase {
+		control?: never;
+		action?: never;
+		render: (setting: import("obsidian").Setting, group: import("obsidian").SettingGroup) => void | (() => void);
+	}
+
+	export type SettingDefinition<K extends string = string> =
+		| SettingDefinitionControl<K>
+		| SettingDefinitionRender
+		| SettingDefinitionAction
+		| SettingDefinitionEmpty;
+
+	export interface SettingDefinitionAddItem {
+		name: string;
+		action: (el: HTMLElement) => void;
+	}
+
+	export interface SettingDefinitionPage<K extends string = string> {
+		type: "page";
+		name: string;
+		desc?: string | DocumentFragment;
+		searchable?: boolean | (() => boolean);
+		visible?: boolean | (() => boolean);
+		items?: SettingDefinitionItem<K>[];
+		page?: () => SettingPage;
+	}
+
+	export type SettingGroupItem<K extends string = string> = SettingDefinition<K> | SettingDefinitionPage<K>;
+
+	export interface SettingDefinitionGroup<K extends string = string> {
+		type: "group" | "list";
+		heading?: string;
+		cls?: string;
+		search?: {
+			placeholder?: string;
+			match: (def: SettingDefinition, query: string) => boolean;
+		};
+		extraButtons?: ((component: import("obsidian").ExtraButtonComponent) => unknown)[];
+		items?: SettingGroupItem<K>[];
+		visible?: boolean | (() => boolean);
+	}
+
+	export interface SettingDefinitionList<K extends string = string> extends SettingDefinitionGroup<K> {
+		type: "list";
+		emptyState?: string | DocumentFragment;
+		onReorder?: (oldIndex: number, newIndex: number) => void;
+		onDelete?: (index: number) => void;
+		addItem?: SettingDefinitionAddItem;
+	}
+
+	export type SettingDefinitionItem<K extends string = string> =
+		| SettingDefinition<K>
+		| SettingDefinitionGroup<K>
+		| SettingDefinitionList<K>
+		| SettingDefinitionPage<K>;
+
+	export abstract class SettingPage {
+		title: string;
+		containerEl: HTMLElement;
+		display(): void;
+		hide(): void;
+	}
+
+	export interface PluginSettingTab {
+		settingItems: SettingDefinitionItem[];
+		getSettingDefinitions(): SettingDefinitionItem[];
+		update(): void;
+		getControlValue(key: string): unknown;
+		setControlValue(key: string, value: unknown): void | Promise<void>;
+		refreshDomState(): void;
 	}
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,6 +10,8 @@ declare global {
 }
 
 declare module "obsidian" {
+	// TODO: remove this compatibility shim once we can depend on the newest Obsidian typings.
+	// We keep it for now because BRAT still supports dual-mode with the older typings.
 	export interface SettingControlBase<V, K extends string = string> {
 		key: K;
 		defaultValue?: V;

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -1,20 +1,7 @@
 import type { TextComponent } from "obsidian";
-import {
-	ButtonComponent,
-	Modal,
-	Platform,
-	SecretComponent,
-	Setting,
-} from "obsidian";
-import {
-	fetchReleaseVersions,
-	type ReleaseVersion,
-	scrubRepositoryUrl,
-} from "src/features/githubUtils";
-import {
-	GHRateLimitError,
-	GitHubResponseError,
-} from "src/utils/GitHubAPIErrors";
+import { ButtonComponent, Modal, Platform, SecretComponent, Setting } from "obsidian";
+import { fetchReleaseVersions, type ReleaseVersion, scrubRepositoryUrl } from "src/features/githubUtils";
+import { GHRateLimitError, GitHubResponseError } from "src/utils/GitHubAPIErrors";
 import { TokenValidator } from "src/utils/TokenValidator";
 import { createGitHubResourceLink } from "src/utils/utils";
 import type BetaPlugins from "../features/BetaPlugins";
@@ -51,6 +38,7 @@ export default class AddNewPluginModal extends Modal {
 	enableAfterInstall: boolean;
 	addPluginButton: ButtonComponent | null = null;
 	cancelButton: ButtonComponent | null = null;
+	onSubmitted?: () => void;
 
 	constructor(
 		plugin: BratPlugin,
@@ -60,6 +48,7 @@ export default class AddNewPluginModal extends Modal {
 		prefillRepo = "",
 		prefillVersion = "",
 		prefillSecretName = "",
+		onSubmitted?: () => void,
 	) {
 		super(plugin.app);
 		this.plugin = plugin;
@@ -70,6 +59,7 @@ export default class AddNewPluginModal extends Modal {
 		this.openSettingsTabAfterwards = openSettingsTabAfterwards;
 		this.updateVersion = updateVersion;
 		this.enableAfterInstall = plugin.settings.enableAfterInstall;
+		this.onSubmitted = onSubmitted;
 	}
 
 	async submitForm(): Promise<void> {
@@ -78,10 +68,7 @@ export default class AddNewPluginModal extends Modal {
 		const scrubbedAddress = scrubRepositoryUrl(this.address);
 
 		// If it's an existing frozen version plugin, update it instead of checking for duplicates
-		const existingFrozenPlugin =
-			this.plugin.settings.pluginSubListFrozenVersion.find(
-				(p) => p.repo === scrubbedAddress,
-			);
+		const existingFrozenPlugin = this.plugin.settings.pluginSubListFrozenVersion.find((p) => p.repo === scrubbedAddress);
 		if (existingFrozenPlugin) {
 			const result = await this.betaPlugins.addPlugin(
 				scrubbedAddress,
@@ -94,6 +81,7 @@ export default class AddNewPluginModal extends Modal {
 				this.secretName,
 			);
 			if (result) {
+				this.onSubmitted?.();
 				this.close();
 			}
 
@@ -122,6 +110,7 @@ export default class AddNewPluginModal extends Modal {
 			this.secretName,
 		);
 		if (result) {
+			this.onSubmitted?.();
 			this.close();
 		}
 
@@ -132,20 +121,12 @@ export default class AddNewPluginModal extends Modal {
 		this.versionSetting?.setDisabled(false);
 	}
 
-	private updateVersionDropdown(
-		settingEl: Setting,
-		versions: ReleaseVersion[],
-		selected = "",
-	): void {
+	private updateVersionDropdown(settingEl: Setting, versions: ReleaseVersion[], selected = ""): void {
 		const text = getTranslations().addBetaPluginModal;
 		let selectedVersion: string;
 
 		settingEl.clear();
-		if (
-			versions.length > 0 &&
-			!selected &&
-			this.plugin.settings.selectLatestPluginVersionByDefault
-		) {
+		if (versions.length > 0 && !selected && this.plugin.settings.selectLatestPluginVersionByDefault) {
 			selectedVersion = "latest";
 			this.version = "latest";
 		} else {
@@ -161,10 +142,7 @@ export default class AddNewPluginModal extends Modal {
 				dropdown.addOption("", text.version.selectVersion);
 				dropdown.addOption("latest", text.version.latestVersion);
 				for (const version of versions) {
-					dropdown.addOption(
-						version.version,
-						`${version.version} ${version.prerelease ? text.version.prereleaseSuffix : ""}`,
-					);
+					dropdown.addOption(version.version, `${version.version} ${version.prerelease ? text.version.prereleaseSuffix : ""}`);
 				}
 				dropdown.onChange((value: string) => {
 					this.version = value;
@@ -178,11 +156,7 @@ export default class AddNewPluginModal extends Modal {
 			// Use suggest modal for many versions
 			settingEl.addButton((button) => {
 				button
-					.setButtonText(
-						selectedVersion === "latest"
-							? text.version.latestVersion
-							: selectedVersion || text.version.selectVersionEllipsis,
-					)
+					.setButtonText(selectedVersion === "latest" ? text.version.latestVersion : selectedVersion || text.version.selectVersionEllipsis)
 					.setClass("brat-version-selector")
 					.setClass("button")
 					.onClick(() => {
@@ -191,21 +165,11 @@ export default class AddNewPluginModal extends Modal {
 							prerelease: false,
 						};
 						const suggestedVersions: ReleaseVersion[] = [latest, ...versions];
-						const modal = new VersionSuggestModal(
-							this.app,
-							this.address,
-							suggestedVersions,
-							selectedVersion,
-							(version: string) => {
-								this.version = version;
-								button.setButtonText(
-									version === "latest"
-										? text.version.latestVersion
-										: version || text.version.selectVersionEllipsis,
-								);
-								this.addPluginButton?.setDisabled(this.version === "");
-							},
-						);
+						const modal = new VersionSuggestModal(this.app, this.address, suggestedVersions, selectedVersion, (version: string) => {
+							this.version = version;
+							button.setButtonText(version === "latest" ? text.version.latestVersion : version || text.version.selectVersionEllipsis);
+							this.addPluginButton?.setDisabled(this.version === "");
+						});
 						modal.open();
 					});
 			});
@@ -238,16 +202,11 @@ export default class AddNewPluginModal extends Modal {
 						addressEl.setValue(this.address);
 						addressEl.onChange((value) => {
 							this.address = scrubRepositoryUrl(value.trim());
-							if (
-								this.version !== "" &&
-								(!this.address || !this.isGitHubRepositoryMatch(this.address))
-							) {
+							if (this.version !== "" && (!this.address || !this.isGitHubRepositoryMatch(this.address))) {
 								// Disable version dropdown if version is set and address is empty
 								if (this.versionSetting) {
 									this.updateVersionDropdown(this.versionSetting, []);
-									this.versionSetting.settingEl.classList.add(
-										"disabled-setting",
-									);
+									this.versionSetting.settingEl.classList.add("disabled-setting");
 									this.versionSetting.setDisabled(true);
 									addressEl.inputEl.classList.remove("valid-repository");
 									addressEl.inputEl.classList.remove("invalid-repository");
@@ -256,45 +215,31 @@ export default class AddNewPluginModal extends Modal {
 
 							// If the GitHub Repository matches the GitHub pattern, enable the "Add Plugin"
 							if (!this.version) {
-								if (this.isGitHubRepositoryMatch(this.address))
-									this.addPluginButton?.setDisabled(false);
+								if (this.isGitHubRepositoryMatch(this.address)) this.addPluginButton?.setDisabled(false);
 								else this.addPluginButton?.setDisabled(true);
 							}
 						});
 
-						addressEl.inputEl.addEventListener(
-							"keydown",
-							(e: KeyboardEvent) => {
-								if (e.key === "Enter") {
-									void (async () => {
-										if (
-											this.address &&
-											((this.updateVersion && this.version !== "") ||
-												!this.updateVersion)
-										) {
-											e.preventDefault();
-											this.addPluginButton?.setDisabled(true);
-											this.cancelButton?.setDisabled(true);
-											this.versionSetting?.setDisabled(true);
-											void this.submitForm();
-										}
+						addressEl.inputEl.addEventListener("keydown", (e: KeyboardEvent) => {
+							if (e.key === "Enter") {
+								void (async () => {
+									if (this.address && ((this.updateVersion && this.version !== "") || !this.updateVersion)) {
+										e.preventDefault();
+										this.addPluginButton?.setDisabled(true);
+										this.cancelButton?.setDisabled(true);
+										this.versionSetting?.setDisabled(true);
+										void this.submitForm();
+									}
 
-										// Populate version dropdown
-										await this.updateRepositoryVersionInfo(
-											this.version,
-											validationStatusEl,
-										);
-									})();
-								}
-							},
-						);
+									// Populate version dropdown
+									await this.updateRepositoryVersionInfo(this.version, validationStatusEl);
+								})();
+							}
+						});
 
 						// Update version dropdown when input loses focus
 						addressEl.inputEl.addEventListener("blur", () => {
-							void this.updateRepositoryVersionInfo(
-								this.version,
-								validationStatusEl,
-							);
+							void this.updateRepositoryVersionInfo(this.version, validationStatusEl);
 						});
 
 						// FIXME
@@ -306,13 +251,10 @@ export default class AddNewPluginModal extends Modal {
 			// Add validation status element (as a separate element)
 			// TODO: Find better way to build the modal
 			const validationStatusEl = formEl.createDiv("validation-status");
-			if (!this.address)
-				validationStatusEl.setText(text.repository.enterAddressToValidate);
+			if (!this.address) validationStatusEl.setText(text.repository.enterAddressToValidate);
 
 			// Then add version dropdown
-			this.versionSetting = new Setting(formEl)
-				.setClass("version-setting")
-				.setClass("disabled-setting");
+			this.versionSetting = new Setting(formEl).setClass("version-setting").setClass("disabled-setting");
 			this.updateVersionDropdown(this.versionSetting, [], this.version);
 			this.versionSetting.setDisabled(true);
 
@@ -322,70 +264,42 @@ export default class AddNewPluginModal extends Modal {
 				.setName(text.token.name)
 				.setDesc(text.token.desc)
 				.addComponent((el) =>
-					new SecretComponent(this.plugin.app, el)
-						.setValue(this.secretName)
-						.onChange((selectedSecretName: string | null) => {
-							void (async () => {
-								// User selected a different secret name (can be null when cleared)
-								this.secretName = selectedSecretName?.trim() || "";
-								if (!this.secretName) {
-									if (
-										this.address &&
-										existBetaPluginInList(this.plugin, this.address)
-									) {
-										updatePluginTokenName(this.plugin, this.address, "");
-										toastMessage(
-											this.plugin,
-											text.token.settingCleared(this.address),
-											3,
-										);
-									}
-									void this.updateRepositoryVersionInfo(
-										this.version,
-										validationStatusEl,
-									);
-									return;
+					new SecretComponent(this.plugin.app, el).setValue(this.secretName).onChange((selectedSecretName: string | null) => {
+						void (async () => {
+							// User selected a different secret name (can be null when cleared)
+							this.secretName = selectedSecretName?.trim() || "";
+							if (!this.secretName) {
+								if (this.address && existBetaPluginInList(this.plugin, this.address)) {
+									updatePluginTokenName(this.plugin, this.address, "");
+									toastMessage(this.plugin, text.token.settingCleared(this.address), 3);
 								}
-								const tokenValue = this.secretName
-									? this.plugin.app.secretStorage.getSecret(this.secretName)
-									: null;
-								if (tokenValue) {
-									this.validToken = await this.validator?.validateToken(
-										tokenValue,
-										this.address,
-									);
-									if (!this.validToken) {
-										this.validateButton?.setButtonText(text.buttons.invalid);
-										this.validateButton?.setDisabled(false);
-									} else {
-										this.validateButton?.setButtonText(text.buttons.valid);
-										this.validateButton?.setDisabled(true);
+								void this.updateRepositoryVersionInfo(this.version, validationStatusEl);
+								return;
+							}
+							const tokenValue = this.secretName ? this.plugin.app.secretStorage.getSecret(this.secretName) : null;
+							if (tokenValue) {
+								this.validToken = await this.validator?.validateToken(tokenValue, this.address);
+								if (!this.validToken) {
+									this.validateButton?.setButtonText(text.buttons.invalid);
+									this.validateButton?.setDisabled(false);
+								} else {
+									this.validateButton?.setButtonText(text.buttons.valid);
+									this.validateButton?.setDisabled(true);
 
-										// Update version dropdown when API key changes
-										if (this.address) {
-											await this.updateRepositoryVersionInfo(
-												this.version,
-												validationStatusEl,
-											);
+									// Update version dropdown when API key changes
+									if (this.address) {
+										await this.updateRepositoryVersionInfo(this.version, validationStatusEl);
 
-											// Update the secret name for this plugin in the settings if it already exists there
-											if (existBetaPluginInList(this.plugin, this.address)) {
-												updatePluginTokenName(
-													this.plugin,
-													this.address,
-													this.secretName,
-												);
-												toastMessage(
-													this.plugin,
-													text.token.settingUpdated(this.address),
-													3,
-												);
-											}
+										// Update the secret name for this plugin in the settings if it already exists there
+										if (existBetaPluginInList(this.plugin, this.address)) {
+											updatePluginTokenName(this.plugin, this.address, this.secretName);
+											toastMessage(this.plugin, text.token.settingUpdated(this.address), 3);
 										}
 									}
 								}
-							})();
-						}),
+							}
+						})();
+					}),
 				);
 
 			// Initialize validator
@@ -393,20 +307,16 @@ export default class AddNewPluginModal extends Modal {
 
 			// Validate the current token if we have a secret name
 			if (this.secretName) {
-				const tokenValue = this.plugin.app.secretStorage.getSecret(
-					this.secretName,
-				);
+				const tokenValue = this.plugin.app.secretStorage.getSecret(this.secretName);
 				if (tokenValue) {
 					// Validate asynchronously on initial load
-					void this.validator
-						?.validateToken(tokenValue, this.address)
-						.then((isValid) => {
-							this.validToken = isValid;
-							if (this.validToken) {
-								this.validateButton?.setButtonText(text.buttons.valid);
-								this.validateButton?.setDisabled(true);
-							}
-						});
+					void this.validator?.validateToken(tokenValue, this.address).then((isValid) => {
+						this.validToken = isValid;
+						if (this.validToken) {
+							this.validateButton?.setButtonText(text.buttons.valid);
+							this.validateButton?.setDisabled(true);
+						}
+					});
 				}
 			}
 
@@ -437,20 +347,11 @@ export default class AddNewPluginModal extends Modal {
 					});
 
 				this.addPluginButton = new ButtonComponent(buttonContainerEl)
-					.setButtonText(
-						this.updateVersion
-							? this.address
-								? text.buttons.changeVersion
-								: text.buttons.addPlugin
-							: text.buttons.addPlugin,
-					)
+					.setButtonText(this.updateVersion ? (this.address ? text.buttons.changeVersion : text.buttons.addPlugin) : text.buttons.addPlugin)
 					.setCta()
 					.onClick(() => {
 						if (this.address !== "") {
-							if (
-								(this.updateVersion && this.version !== "") ||
-								!this.updateVersion
-							) {
+							if ((this.updateVersion && this.version !== "") || !this.updateVersion) {
 								// Submit the form
 								this.addPluginButton?.setDisabled(true);
 								this.addPluginButton?.setButtonText(text.buttons.installing);
@@ -462,8 +363,7 @@ export default class AddNewPluginModal extends Modal {
 					});
 
 				// Disable "Add Plugin" if adding a frozen version only
-				if (this.updateVersion || this.address === "")
-					this.addPluginButton?.setDisabled(true);
+				if (this.updateVersion || this.address === "") this.addPluginButton?.setDisabled(true);
 			});
 
 			const newDiv = formEl.createDiv();
@@ -511,16 +411,11 @@ export default class AddNewPluginModal extends Modal {
 	 * @param validationStatusEl - The error element (used for errors, incl. GitHub Rate limit)
 	 * @returns {Promise<void>}
 	 */
-	private async updateRepositoryVersionInfo(
-		selectedVersion = "",
-		validationStatusEl?: HTMLElement,
-	) {
+	private async updateRepositoryVersionInfo(selectedVersion = "", validationStatusEl?: HTMLElement) {
 		const text = getTranslations().addBetaPluginModal;
 		const validateInputEl = this.repositoryAddressEl;
 		if (this.plugin.settings.debuggingMode) {
-			console.debug(
-				`[BRAT] Updating version dropdown for ${this.address} with selected version ${selectedVersion}`,
-			);
+			console.debug(`[BRAT] Updating version dropdown for ${this.address} with selected version ${selectedVersion}`);
 		}
 
 		if (!this.address) {
@@ -542,26 +437,18 @@ export default class AddNewPluginModal extends Modal {
 			// Get the actual token value from SecretStorage
 			let tokenToUse = "";
 			if (this.secretName) {
-				const tokenValue = this.plugin.app.secretStorage.getSecret(
-					this.secretName,
-				);
+				const tokenValue = this.plugin.app.secretStorage.getSecret(this.secretName);
 				if (tokenValue) {
 					tokenToUse = tokenValue;
 				}
 			} else if (this.plugin.settings.globalTokenName) {
-				const globalToken = this.plugin.app.secretStorage.getSecret(
-					this.plugin.settings.globalTokenName,
-				);
+				const globalToken = this.plugin.app.secretStorage.getSecret(this.plugin.settings.globalTokenName);
 				if (globalToken) {
 					tokenToUse = globalToken;
 				}
 			}
 
-			const versions = await fetchReleaseVersions(
-				scrubbedAddress,
-				this.plugin.settings.debuggingMode,
-				tokenToUse,
-			);
+			const versions = await fetchReleaseVersions(scrubbedAddress, this.plugin.settings.debuggingMode, tokenToUse);
 
 			if (versions && versions.length > 0) {
 				// Add valid-repository class
@@ -573,11 +460,7 @@ export default class AddNewPluginModal extends Modal {
 					this.versionSetting.settingEl.classList.remove("disabled-setting");
 					this.versionSetting.setDisabled(false);
 					// Add new dropdown to existing version setting
-					this.updateVersionDropdown(
-						this.versionSetting,
-						versions,
-						selectedVersion,
-					);
+					this.updateVersionDropdown(this.versionSetting, versions, selectedVersion);
 				}
 			} else {
 				// Add invalid-repository class
@@ -595,9 +478,7 @@ export default class AddNewPluginModal extends Modal {
 				// Add invalid-repository class
 				validateInputEl?.inputEl.classList.remove("valid-repository");
 				validateInputEl?.inputEl.classList.add("validation-error");
-				validationStatusEl?.setText(
-					text.repository.rateLimitExceeded(error.getMinutesToReset()),
-				);
+				validationStatusEl?.setText(text.repository.rateLimitExceeded(error.getMinutesToReset()));
 
 				if (this.versionSetting) {
 					this.versionSetting.settingEl.classList.add("disabled-setting");
@@ -605,16 +486,9 @@ export default class AddNewPluginModal extends Modal {
 					this.addPluginButton?.setDisabled(true);
 				}
 
-				toastMessage(
-					this.plugin,
-					text.repository.rateLimitToast(error.message),
-					20,
-					(): void => {
-						window.open(
-							"https://github.com/TfTHacker/obsidian42-brat/blob/main/BRAT-DEVELOPER-GUIDE.md#github-api-rate-limits",
-						);
-					},
-				);
+				toastMessage(this.plugin, text.repository.rateLimitToast(error.message), 20, (): void => {
+					window.open("https://github.com/TfTHacker/obsidian42-brat/blob/main/BRAT-DEVELOPER-GUIDE.md#github-api-rate-limits");
+				});
 
 				// toastMessage(this.plugin, `GitHub API rate limit exceeded. Try again in ${error.getMinutesToReset()} minutes.`, 10);
 			}
@@ -629,9 +503,7 @@ export default class AddNewPluginModal extends Modal {
 						validationStatusEl?.setText(text.repository.accessDenied);
 						break;
 					default:
-						validationStatusEl?.setText(
-							text.repository.error(gitHubError.message),
-						);
+						validationStatusEl?.setText(text.repository.error(gitHubError.message));
 						break;
 				}
 
@@ -640,11 +512,7 @@ export default class AddNewPluginModal extends Modal {
 				this.versionSetting?.setDisabled(true);
 				this.addPluginButton?.setDisabled(true);
 
-				toastMessage(
-					this.plugin,
-					text.repository.gitHubResponseToast(gitHubError.message),
-					20,
-				);
+				toastMessage(this.plugin, text.repository.gitHubResponseToast(gitHubError.message), 20);
 			}
 		}
 	}
@@ -666,8 +534,7 @@ export default class AddNewPluginModal extends Modal {
 		// Match either format:
 		// 1. user/repo
 		// 2. https://github.com/user/repo
-		const githubPattern =
-			/^(?:https?:\/\/github\.com\/)?([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+)$/i;
+		const githubPattern = /^(?:https?:\/\/github\.com\/)?([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+)$/i;
 
 		return githubPattern.test(cleanAddress);
 	}

--- a/src/ui/AddNewTheme.ts
+++ b/src/ui/AddNewTheme.ts
@@ -1,5 +1,6 @@
 import { ButtonComponent, Modal, Setting } from "obsidian";
 import { themeSave } from "../features/themes";
+import { getTranslations } from "../i18n";
 import type BratPlugin from "../main";
 import { existBetaThemeinInList } from "../settings";
 import { toastMessage } from "../utils/notifications";
@@ -12,41 +13,41 @@ export default class AddNewTheme extends Modal {
 	plugin: BratPlugin;
 	address: string;
 	openSettingsTabAfterwards: boolean;
+	onSubmitted?: () => void;
 
-	constructor(plugin: BratPlugin, openSettingsTabAfterwards = false) {
+	constructor(plugin: BratPlugin, openSettingsTabAfterwards = false, onSubmitted?: () => void) {
 		super(plugin.app);
 		this.plugin = plugin;
 		this.address = "";
 		this.openSettingsTabAfterwards = openSettingsTabAfterwards;
+		this.onSubmitted = onSubmitted;
 	}
 
 	async submitForm(): Promise<void> {
+		const text = getTranslations();
 		if (this.address === "") return;
 		const scrubbedAddress = this.address.replace("https://github.com/", "");
 		if (existBetaThemeinInList(this.plugin, scrubbedAddress)) {
-			toastMessage(
-				this.plugin,
-				"This theme is already in the list for beta testing",
-				10,
-			);
+			toastMessage(this.plugin, text.addBetaThemeModal.alreadyInList, 10);
 			return;
 		}
 
 		if (await themeSave(this.plugin, scrubbedAddress, true)) {
+			this.onSubmitted?.();
 			this.close();
 		}
 	}
 
 	onOpen(): void {
+		const text = getTranslations();
+		const commonText = text.common;
 		this.contentEl.createEl("h4", {
-			text: "GitHub repository for beta theme:",
+			text: text.addBetaThemeModal.heading.githubRepositoryForBetaTheme,
 		});
 		this.contentEl.createEl("form", {}, (formEl) => {
 			formEl.addClass("brat-modal");
 			new Setting(formEl).addText((textEl) => {
-				textEl.setPlaceholder(
-					"Repository (example: https://github.com/GitHubUserName/repository-name",
-				);
+				textEl.setPlaceholder(text.addBetaPluginModal.repository.placeholder);
 				textEl.setValue(this.address);
 				textEl.onChange((value) => {
 					this.address = value.trim();
@@ -67,14 +68,12 @@ export default class AddNewTheme extends Modal {
 			});
 
 			formEl.createDiv("modal-button-container", (buttonContainerEl) => {
-				new ButtonComponent(buttonContainerEl)
-					.setButtonText("Never mind")
-					.onClick(() => {
-						this.close();
-					});
+				new ButtonComponent(buttonContainerEl).setButtonText(text.addBetaPluginModal.buttons.neverMind).onClick(() => {
+					this.close();
+				});
 
 				new ButtonComponent(buttonContainerEl)
-					.setButtonText("Add theme")
+					.setButtonText(text.settings.betaThemeList.addBetaTheme)
 					.setCta()
 					.onClick((e: Event) => {
 						e.preventDefault();
@@ -90,7 +89,7 @@ export default class AddNewTheme extends Modal {
 				href: "https://bit.ly/o42-twitter",
 				text: "TFTHacker",
 			});
-			byTfThacker.appendText(" and ");
+			byTfThacker.appendText(commonText.and);
 			byTfThacker.createEl("a", {
 				href: "https://github.com/johannrichard",
 				// eslint-disable-next-line obsidianmd/ui/sentence-case -- preserve author's lowercase handle

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -3,29 +3,29 @@ import type {
 	ButtonComponent,
 	ExtraButtonComponent,
 	SecretComponent,
+	SettingDefinition,
+	SettingDefinitionGroup,
+	SettingDefinitionItem,
+	SettingDefinitionList,
+	SettingGroupItem,
 	ToggleComponent,
 } from "obsidian";
-import {
-	PluginSettingTab,
-	SecretComponent as SecretComponentClass,
-	Setting,
-	SettingGroup,
-} from "obsidian";
-import { TokenValidator } from "src/utils/TokenValidator";
+import { PluginSettingTab, requireApiVersion, SecretComponent as SecretComponentClass, Setting, SettingGroup } from "obsidian";
+import { type GitHubTokenInfo, validateGitHubToken } from "../features/githubUtils";
 import { themeDelete } from "../features/themes";
 import { getTranslations } from "../i18n";
 import type BratPlugin from "../main";
+import type { Settings as BratPluginSettings, PluginVersion, ThemeInforamtion } from "../settings";
 import { toastMessage } from "../utils/notifications";
 import { createGitHubResourceLink, createLink } from "../utils/utils";
 import AddNewTheme from "./AddNewTheme";
-import { promotionalLinks } from "./Promotional";
+
+type BratSettingsKey = Extract<keyof BratPluginSettings, string>;
 
 export class BratSettingsTab extends PluginSettingTab {
 	plugin: BratPlugin;
 	accessTokenSetting: SecretComponent | null = null;
 	accessTokenButton: ButtonComponent | null = null;
-	tokenInfo: HTMLElement | null = null;
-	validator: TokenValidator | null = null;
 
 	constructor(app: App, plugin: BratPlugin) {
 		super(app, plugin);
@@ -48,6 +48,94 @@ export class BratSettingsTab extends PluginSettingTab {
 		}
 	}
 
+	override getSettingDefinitions(): SettingDefinitionItem<BratSettingsKey>[] {
+		const text = getTranslations().settings;
+
+		return [
+			{
+				name: text.general.autoEnablePluginsAfterInstallation.name,
+				desc: text.general.autoEnablePluginsAfterInstallation.desc,
+				control: { type: "toggle", key: "enableAfterInstall" },
+			},
+			{
+				name: text.general.autoUpdatePluginsAtStartup.name,
+				desc: text.general.autoUpdatePluginsAtStartup.desc,
+				control: { type: "toggle", key: "updateAtStartup" },
+			},
+			{
+				name: text.general.autoUpdateThemesAtStartup.name,
+				desc: text.general.autoUpdateThemesAtStartup.desc,
+				control: { type: "toggle", key: "updateThemesAtStartup" },
+			},
+			{
+				name: text.general.selectLatestPluginVersionByDefault.name,
+				desc: text.general.selectLatestPluginVersionByDefault.desc,
+				control: {
+					type: "toggle",
+					key: "selectLatestPluginVersionByDefault",
+				},
+			},
+			{
+				name: text.general.allowIncompatiblePlugins.name,
+				desc: text.general.allowIncompatiblePlugins.desc,
+				control: { type: "toggle", key: "allowIncompatiblePlugins" },
+			},
+			this.createPluginListDefinition(),
+			this.createThemeListDefinition(),
+			{
+				type: "group",
+				heading: text.monitoring.heading,
+				items: [
+					{
+						name: text.monitoring.enableNotifications.name,
+						desc: text.monitoring.enableNotifications.desc,
+						control: { type: "toggle", key: "notificationsEnabled" },
+					},
+					{
+						name: text.monitoring.enableLogging.name,
+						desc: text.monitoring.enableLogging.desc,
+						control: { type: "toggle", key: "loggingEnabled" },
+					},
+					{
+						name: text.monitoring.bratLogFileLocation.name,
+						desc: text.monitoring.bratLogFileLocation.desc,
+						control: {
+							type: "text",
+							key: "loggingPath",
+							placeholder: text.monitoring.bratLogFileLocation.placeholder,
+						},
+					},
+					{
+						name: text.monitoring.enableVerboseLogging.name,
+						desc: text.monitoring.enableVerboseLogging.desc,
+						control: { type: "toggle", key: "loggingVerboseEnabled" },
+					},
+					{
+						name: text.monitoring.debuggingMode.name,
+						desc: text.monitoring.debuggingMode.desc,
+						control: { type: "toggle", key: "debuggingMode" },
+					},
+				],
+			},
+			{
+				type: "group",
+				heading: text.githubPersonalAccessToken.heading,
+				items: [
+					{
+						name: text.githubPersonalAccessToken.personalAccessToken.name,
+						desc: createLink({
+							prependText: text.githubPersonalAccessToken.personalAccessToken.desc.prependText,
+							url: "https://github.com/settings/tokens/new?scopes=public_repo",
+							text: text.githubPersonalAccessToken.personalAccessToken.desc.linkText,
+							appendText: text.githubPersonalAccessToken.personalAccessToken.desc.appendText,
+						}),
+						render: (setting) => this.renderPersonalAccessTokenSetting(setting),
+					},
+				],
+			},
+		];
+	}
+
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();
@@ -58,45 +146,37 @@ export class BratSettingsTab extends PluginSettingTab {
 			.setName(text.general.autoEnablePluginsAfterInstallation.name)
 			.setDesc(text.general.autoEnablePluginsAfterInstallation.desc)
 			.addToggle((cb: ToggleComponent) => {
-				cb.setValue(this.plugin.settings.enableAfterInstall).onChange(
-					async (value: boolean) => {
-						this.plugin.settings.enableAfterInstall = value;
-						await this.plugin.saveSettings();
-					},
-				);
+				cb.setValue(this.plugin.settings.enableAfterInstall).onChange(async (value: boolean) => {
+					this.plugin.settings.enableAfterInstall = value;
+					await this.plugin.saveSettings();
+				});
 			});
 
 		new Setting(containerEl)
 			.setName(text.general.autoUpdatePluginsAtStartup.name)
 			.setDesc(text.general.autoUpdatePluginsAtStartup.desc)
 			.addToggle((cb: ToggleComponent) => {
-				cb.setValue(this.plugin.settings.updateAtStartup).onChange(
-					async (value: boolean) => {
-						this.plugin.settings.updateAtStartup = value;
-						await this.plugin.saveSettings();
-					},
-				);
+				cb.setValue(this.plugin.settings.updateAtStartup).onChange(async (value: boolean) => {
+					this.plugin.settings.updateAtStartup = value;
+					await this.plugin.saveSettings();
+				});
 			});
 
 		new Setting(containerEl)
 			.setName(text.general.autoUpdateThemesAtStartup.name)
 			.setDesc(text.general.autoUpdateThemesAtStartup.desc)
 			.addToggle((cb: ToggleComponent) => {
-				cb.setValue(this.plugin.settings.updateThemesAtStartup).onChange(
-					async (value: boolean) => {
-						this.plugin.settings.updateThemesAtStartup = value;
-						await this.plugin.saveSettings();
-					},
-				);
+				cb.setValue(this.plugin.settings.updateThemesAtStartup).onChange(async (value: boolean) => {
+					this.plugin.settings.updateThemesAtStartup = value;
+					await this.plugin.saveSettings();
+				});
 			});
 
 		new Setting(containerEl)
 			.setName(text.general.selectLatestPluginVersionByDefault.name)
 			.setDesc(text.general.selectLatestPluginVersionByDefault.desc)
 			.addToggle((cb: ToggleComponent) => {
-				cb.setValue(
-					this.plugin.settings.selectLatestPluginVersionByDefault,
-				).onChange(async (value: boolean) => {
+				cb.setValue(this.plugin.settings.selectLatestPluginVersionByDefault).onChange(async (value: boolean) => {
 					this.plugin.settings.selectLatestPluginVersionByDefault = value;
 					await this.plugin.saveSettings();
 				});
@@ -106,27 +186,16 @@ export class BratSettingsTab extends PluginSettingTab {
 			.setName(text.general.allowIncompatiblePlugins.name)
 			.setDesc(text.general.allowIncompatiblePlugins.desc)
 			.addToggle((cb: ToggleComponent) => {
-				cb.setValue(this.plugin.settings.allowIncompatiblePlugins).onChange(
-					async (value: boolean) => {
-						this.plugin.settings.allowIncompatiblePlugins = value;
-						await this.plugin.saveSettings();
-					},
-				);
+				cb.setValue(this.plugin.settings.allowIncompatiblePlugins).onChange(async (value: boolean) => {
+					this.plugin.settings.allowIncompatiblePlugins = value;
+					await this.plugin.saveSettings();
+				});
 			});
 
-		promotionalLinks(containerEl, true);
-		containerEl.createEl("hr");
-		const frozenVersions = new Map(
-			this.plugin.settings.pluginSubListFrozenVersion.map((f) => [f.repo, f]),
-		);
-		const pluginContainers = new Map<
-			string,
-			{ container: HTMLElement; pluginName: string }
-		>();
+		const frozenVersions = new Map(this.plugin.settings.pluginSubListFrozenVersion.map((f) => [f.repo, f]));
+		const pluginContainers = new Map<string, { container: HTMLElement; pluginName: string }>();
 
-		const betaPluginGroup = new SettingGroup(containerEl).setHeading(
-			text.betaPluginList.heading,
-		);
+		const betaPluginGroup = new SettingGroup(containerEl).setHeading(text.betaPluginList.heading);
 
 		betaPluginGroup.addSearch((cb) => {
 			cb.setPlaceholder(text.betaPluginList.filterPlaceholder);
@@ -148,25 +217,7 @@ export class BratSettingsTab extends PluginSettingTab {
 		});
 
 		betaPluginGroup.addSetting((setting) => {
-			// eslint-disable-next-line obsidianmd/prefer-active-doc -- BRAT compatibility: activeDocument breaks settings description rendering
-			const pluginListDescription = document.createDocumentFragment();
-			pluginListDescription.createEl("div", {
-				text: text.betaPluginList.description.intro,
-			});
-
-			pluginListDescription.createEl("p");
-			pluginListDescription.createEl("div", {
-				text: text.betaPluginList.description.editAndRemove,
-			});
-			pluginListDescription.createEl("p");
-			pluginListDescription
-				.createEl("span")
-				.createEl("b", { text: text.betaPluginList.description.noteLabel });
-			pluginListDescription.createSpan({
-				text: text.betaPluginList.description.noteText,
-			});
-
-			setting.setDesc(pluginListDescription);
+			setting.setDesc(this.createPluginListDescriptionFragment());
 			setting.addButton((cb: ButtonComponent) => {
 				cb.setButtonText(text.betaPluginList.addBetaPlugin)
 					.setCta()
@@ -180,22 +231,13 @@ export class BratSettingsTab extends PluginSettingTab {
 			const bp = frozenVersions.get(p);
 			betaPluginGroup.addSetting((pluginSettingContainer) => {
 				const secretName = bp?.tokenName || "";
-				const secretValue = secretName
-					? this.plugin.app.secretStorage.getSecret(secretName)
-					: "";
+				const secretValue = secretName ? this.plugin.app.secretStorage.getSecret(secretName) : "";
 				const isSecretMissing = Boolean(secretName && !secretValue);
 
 				// eslint-disable-next-line obsidianmd/prefer-active-doc -- BRAT compatibility: activeDocument breaks settings description rendering
 				const pluginDescription = document.createDocumentFragment();
-				const trackedVersionText = bp?.version
-					? text.betaPluginList.trackedVersion(
-							bp.version,
-							bp.version !== "latest",
-						)
-					: "";
-				const incompatibleText = bp?.isIncompatible
-					? text.betaPluginList.incompatible
-					: "";
+				const trackedVersionText = bp?.version ? text.betaPluginList.trackedVersion(bp.version, bp.version !== "latest") : "";
+				const incompatibleText = bp?.isIncompatible ? text.betaPluginList.incompatible : "";
 				pluginDescription.createDiv({
 					text: `${trackedVersionText}${incompatibleText}`,
 				});
@@ -207,9 +249,7 @@ export class BratSettingsTab extends PluginSettingTab {
 					});
 				}
 
-				pluginSettingContainer
-					.setName(createGitHubResourceLink(p))
-					.setDesc(pluginDescription);
+				pluginSettingContainer.setName(createGitHubResourceLink(p)).setDesc(pluginDescription);
 
 				const containerElement = pluginSettingContainer.settingEl;
 				containerElement.addClass("brat-plugin-item");
@@ -232,25 +272,13 @@ export class BratSettingsTab extends PluginSettingTab {
 					pluginSettingContainer.addButton((btn: ButtonComponent) => {
 						if (isSecretMissing) {
 							// Token name configured but secret missing: make button red, disabled, and show informative tooltip
-							btn
-								.setIcon("sync")
-								.setTooltip(
-									text.betaPluginList.secretMissingTooltip(secretName),
-								)
-								.setWarning()
-								.setDisabled(true);
+							btn.setIcon("sync").setTooltip(text.betaPluginList.secretMissingTooltip(secretName)).setWarning().setDisabled(true);
 						} else {
 							btn
 								.setIcon("sync")
 								.setTooltip(text.betaPluginList.checkAndUpdatePlugin)
 								.onClick(async () => {
-									await this.plugin.betaPlugins.updatePlugin(
-										p,
-										false,
-										true,
-										false,
-										bp?.tokenName || "",
-									);
+									await this.plugin.betaPlugins.updatePlugin(p, false, true, false, bp?.tokenName || "");
 								});
 						}
 					});
@@ -259,9 +287,7 @@ export class BratSettingsTab extends PluginSettingTab {
 				// Container for the edit and removal buttons
 				pluginSettingContainer
 					.addButton((btn: ButtonComponent) => {
-						btn
-							.setIcon("edit")
-							.setTooltip(text.betaPluginList.changeVersionAndUpdateSettings);
+						btn.setIcon("edit").setTooltip(text.betaPluginList.changeVersionAndUpdateSettings);
 
 						if (isSecretMissing) {
 							btn.setWarning();
@@ -299,13 +325,8 @@ export class BratSettingsTab extends PluginSettingTab {
 			});
 		}
 
-		const themeContainers = new Map<
-			string,
-			{ container: HTMLElement; themeName: string }
-		>();
-		const betaThemeGroup = new SettingGroup(containerEl).setHeading(
-			text.betaThemeList.heading,
-		);
+		const themeContainers = new Map<string, { container: HTMLElement; themeName: string }>();
+		const betaThemeGroup = new SettingGroup(containerEl).setHeading(text.betaThemeList.heading);
 
 		betaThemeGroup.addSetting((setting) => {
 			setting.addButton((cb: ButtonComponent) => {
@@ -362,8 +383,7 @@ export class BratSettingsTab extends PluginSettingTab {
 						.setIcon("cross")
 						.setTooltip(text.betaThemeList.deleteThisBetaTheme)
 						.onClick(() => {
-							if (btn.buttonEl.textContent === "")
-								btn.setButtonText(text.betaThemeList.confirmRemoval);
+							if (btn.buttonEl.textContent === "") btn.setButtonText(text.betaThemeList.confirmRemoval);
 							else {
 								const { buttonEl } = btn;
 								const { parentElement } = buttonEl;
@@ -377,9 +397,7 @@ export class BratSettingsTab extends PluginSettingTab {
 			});
 		}
 
-		const monitoringGroup = new SettingGroup(containerEl).setHeading(
-			text.monitoring.heading,
-		);
+		const monitoringGroup = new SettingGroup(containerEl).setHeading(text.monitoring.heading);
 
 		monitoringGroup.addSetting((setting) => {
 			setting
@@ -399,12 +417,10 @@ export class BratSettingsTab extends PluginSettingTab {
 				.setName(text.monitoring.enableLogging.name)
 				.setDesc(text.monitoring.enableLogging.desc)
 				.addToggle((cb: ToggleComponent) => {
-					cb.setValue(this.plugin.settings.loggingEnabled).onChange(
-						(value: boolean) => {
-							this.plugin.settings.loggingEnabled = value;
-							void this.plugin.saveSettings();
-						},
-					);
+					cb.setValue(this.plugin.settings.loggingEnabled).onChange((value: boolean) => {
+						this.plugin.settings.loggingEnabled = value;
+						void this.plugin.saveSettings();
+					});
 				});
 		});
 
@@ -427,12 +443,10 @@ export class BratSettingsTab extends PluginSettingTab {
 				.setName(text.monitoring.enableVerboseLogging.name)
 				.setDesc(text.monitoring.enableVerboseLogging.desc)
 				.addToggle((cb: ToggleComponent) => {
-					cb.setValue(this.plugin.settings.loggingVerboseEnabled).onChange(
-						(value: boolean) => {
-							this.plugin.settings.loggingVerboseEnabled = value;
-							void this.plugin.saveSettings();
-						},
-					);
+					cb.setValue(this.plugin.settings.loggingVerboseEnabled).onChange((value: boolean) => {
+						this.plugin.settings.loggingVerboseEnabled = value;
+						void this.plugin.saveSettings();
+					});
 				});
 		});
 
@@ -441,73 +455,52 @@ export class BratSettingsTab extends PluginSettingTab {
 				.setName(text.monitoring.debuggingMode.name)
 				.setDesc(text.monitoring.debuggingMode.desc)
 				.addToggle((cb: ToggleComponent) => {
-					cb.setValue(this.plugin.settings.debuggingMode).onChange(
-						(value: boolean) => {
-							this.plugin.settings.debuggingMode = value;
-							void this.plugin.saveSettings();
-						},
-					);
+					cb.setValue(this.plugin.settings.debuggingMode).onChange((value: boolean) => {
+						this.plugin.settings.debuggingMode = value;
+						void this.plugin.saveSettings();
+					});
 				});
 		});
 
 		// Personal access token setting
-		const tokenSection = new SettingGroup(containerEl).setHeading(
-			text.githubPersonalAccessToken.heading,
-		);
+		const tokenSection = new SettingGroup(containerEl).setHeading(text.githubPersonalAccessToken.heading);
 
 		let currentTokenValue = "";
 		tokenSection.addSetting((tokenSetting) => {
-			tokenSetting
-				.setName(text.githubPersonalAccessToken.personalAccessToken.name)
-				.setDesc(
-					createLink({
-						prependText:
-							text.githubPersonalAccessToken.personalAccessToken.desc
-								.prependText,
-						url: "https://github.com/settings/tokens/new?scopes=public_repo",
-						text: text.githubPersonalAccessToken.personalAccessToken.desc
-							.linkText,
-						appendText:
-							text.githubPersonalAccessToken.personalAccessToken.desc
-								.appendText,
-					}),
-				);
-
-			// Create SecretComponent - displays secret NAME selector
-			this.accessTokenSetting = new SecretComponentClass(
-				this.plugin.app,
-				tokenSetting.controlEl,
+			tokenSetting.setName(text.githubPersonalAccessToken.personalAccessToken.name).setDesc(
+				createLink({
+					prependText: text.githubPersonalAccessToken.personalAccessToken.desc.prependText,
+					url: "https://github.com/settings/tokens/new?scopes=public_repo",
+					text: text.githubPersonalAccessToken.personalAccessToken.desc.linkText,
+					appendText: text.githubPersonalAccessToken.personalAccessToken.desc.appendText,
+				}),
 			);
 
-			// Set the component to show the current secret name from settings
-			this.accessTokenSetting
-				.setValue(this.plugin.settings.globalTokenName || "")
-				.onChange((secretName: string | null) => {
-					void (async () => {
-						// secretName is the NAME of the secret, not the value (can be null when cleared)
-						const normalizedName = secretName?.trim() || "";
-						this.plugin.settings.globalTokenName = normalizedName;
-						await this.plugin.saveSettings();
+			// Create SecretComponent - displays secret NAME selector
+			this.accessTokenSetting = new SecretComponentClass(this.plugin.app, tokenSetting.controlEl);
 
-						// Get the actual token value for validation
-						if (normalizedName) {
-							currentTokenValue =
-								this.plugin.app.secretStorage.getSecret(normalizedName) || "";
-							this.accessTokenButton?.setDisabled(false);
-						} else {
-							currentTokenValue = "";
-							this.accessTokenButton?.setDisabled(true);
-							await this.validator?.validateToken("");
-						}
-					})();
-				});
+			// Set the component to show the current secret name from settings
+			this.accessTokenSetting.setValue(this.plugin.settings.globalTokenName || "").onChange((secretName: string | null) => {
+				void (async () => {
+					// secretName is the NAME of the secret, not the value (can be null when cleared)
+					const normalizedName = secretName?.trim() || "";
+					this.plugin.settings.globalTokenName = normalizedName;
+					await this.plugin.saveSettings();
+
+					// Get the actual token value for validation
+					if (normalizedName) {
+						currentTokenValue = this.plugin.app.secretStorage.getSecret(normalizedName) || "";
+						await this.validateGlobalTokenAndUpdateButton(currentTokenValue);
+					} else {
+						currentTokenValue = "";
+						await this.validateGlobalTokenAndUpdateButton("");
+					}
+				})();
+			});
 
 			// Get initial token value for validation
 			if (this.plugin.settings.globalTokenName) {
-				currentTokenValue =
-					this.plugin.app.secretStorage.getSecret(
-						this.plugin.settings.globalTokenName,
-					) || "";
+				currentTokenValue = this.plugin.app.secretStorage.getSecret(this.plugin.settings.globalTokenName) || "";
 			}
 
 			tokenSetting
@@ -519,7 +512,7 @@ export class BratSettingsTab extends PluginSettingTab {
 							await this.plugin.saveSettings();
 							this.accessTokenSetting?.setValue("");
 							currentTokenValue = "";
-							await this.validator?.validateToken("");
+							await this.validateGlobalTokenAndUpdateButton("");
 						});
 				})
 				.addButton((btn: ButtonComponent) => {
@@ -530,30 +523,366 @@ export class BratSettingsTab extends PluginSettingTab {
 						.setCta()
 						.onClick(async () => {
 							if (currentTokenValue) {
-								await this.validator?.validateToken(currentTokenValue);
+								await this.validateGlobalTokenAndUpdateButton(currentTokenValue);
 							}
 						});
 				})
 				.then(() => {
-					this.tokenInfo = this.createTokenInfoElement(containerEl);
-					this.validator = new TokenValidator(this.tokenInfo);
-
-					// Validate the current token on load
-					void this.validator
-						?.validateToken(currentTokenValue)
-						.then((valid) => {
-							this.accessTokenButton?.setDisabled(
-								valid || !this.plugin.settings.globalTokenName,
-							);
-						});
+					void this.validateGlobalTokenAndUpdateButton(currentTokenValue);
 				});
 		});
 	}
 
-	private createTokenInfoElement(containerEl: HTMLElement): HTMLElement {
-		const tokenInfo = containerEl.createDiv({ cls: "brat-token-info" });
-		tokenInfo.createDiv({ cls: "brat-token-status" });
-		tokenInfo.createDiv({ cls: "brat-token-details" });
-		return tokenInfo;
+	private createPluginListDefinition(): SettingDefinitionList<BratSettingsKey> {
+		const text = getTranslations().settings;
+		const frozenVersions = new Map(this.plugin.settings.pluginSubListFrozenVersion.map((f) => [f.repo, f]));
+
+		return {
+			type: "list",
+			heading: text.betaPluginList.heading,
+			search: this.createListSearch(text.betaPluginList.filterPlaceholder),
+			addItem: {
+				name: text.betaPluginList.addBetaPlugin,
+				action: () => {
+					this.plugin.betaPlugins.displayAddNewPluginModal(true, false, "", "", "", () => this.update());
+				},
+			},
+			items: [
+				this.createPluginListDescriptionItem(),
+				...this.plugin.settings.pluginList.map((repository) => {
+					const trackedPlugin = frozenVersions.get(repository);
+					return {
+						name: repository,
+						desc: this.createTrackedPluginDescriptionText(trackedPlugin),
+						render: (setting: Setting) => {
+							this.renderTrackedPluginSetting(setting, repository, trackedPlugin);
+						},
+					};
+				}),
+			],
+		};
+	}
+
+	private createThemeListDefinition(): SettingDefinitionList<BratSettingsKey> {
+		const text = getTranslations().settings;
+
+		return {
+			type: "list",
+			heading: text.betaThemeList.heading,
+			search: this.createListSearch(text.betaThemeList.filterPlaceholder),
+			addItem: {
+				name: text.betaThemeList.addBetaTheme,
+				action: () => {
+					this.plugin.app.setting.close();
+					new AddNewTheme(this.plugin, true, () => this.update()).open();
+				},
+			},
+			items: this.plugin.settings.themesList.map((theme) => ({
+				name: theme.repo,
+				render: (setting) => {
+					this.renderTrackedThemeSetting(setting, theme);
+				},
+			})),
+		};
+	}
+
+	private createPluginListDescriptionItem(): SettingGroupItem<BratSettingsKey> {
+		const guideUrl =
+			"https://github.com/TfTHacker/obsidian42-brat/blob/main/BRAT-DEVELOPER-GUIDE.md#managing-beta-plugin-and-theme-lists-in-settings";
+
+		return {
+			name: "",
+			searchable: false,
+			render: (setting) => {
+				setting.settingEl.empty();
+				const line = setting.settingEl.createDiv();
+				line.createSpan({
+					text: getTranslations().settings.betaPluginList.description.editAndRemove,
+				});
+				line.appendText(" ");
+				line.createEl("a", {
+					href: guideUrl,
+					text: "Learn more",
+				});
+			},
+		};
+	}
+
+	private createPluginListDescriptionFragment(): DocumentFragment {
+		const guideUrl =
+			"https://github.com/TfTHacker/obsidian42-brat/blob/main/BRAT-DEVELOPER-GUIDE.md#managing-beta-plugin-and-theme-lists-in-settings";
+		const text = getTranslations().settings.betaPluginList.description;
+		// eslint-disable-next-line obsidianmd/prefer-active-doc -- BRAT compatibility: activeDocument breaks settings description rendering
+		const fragment = document.createDocumentFragment();
+		const line = fragment.createEl("div");
+		line.createSpan({ text: text.editAndRemove });
+		line.appendText(" ");
+		line.createEl("a", {
+			href: guideUrl,
+			text: "Learn more",
+		});
+		return fragment;
+	}
+
+	private createTrackedPluginDescriptionFragment(trackedPlugin?: PluginVersion): DocumentFragment {
+		const text = getTranslations().settings.betaPluginList;
+		const secretName = trackedPlugin?.tokenName || "";
+		const secretValue = secretName ? this.plugin.app.secretStorage.getSecret(secretName) : "";
+		const isSecretMissing = Boolean(secretName && !secretValue);
+		// eslint-disable-next-line obsidianmd/prefer-active-doc -- BRAT compatibility: activeDocument breaks settings description rendering
+		const pluginDescription = document.createDocumentFragment();
+		const trackedVersionText = trackedPlugin?.version ? text.trackedVersion(trackedPlugin.version, trackedPlugin.version !== "latest") : "";
+		const incompatibleText = trackedPlugin?.isIncompatible ? text.incompatible : "";
+		pluginDescription.createDiv({
+			text: `${trackedVersionText}${incompatibleText}`,
+		});
+		if (isSecretMissing) {
+			pluginDescription.createDiv({
+				text: text.secretMissing(secretName),
+				cls: "mod-warning",
+				title: text.secretMissingTitle,
+			});
+		}
+		return pluginDescription;
+	}
+
+	private createTrackedPluginDescriptionText(trackedPlugin?: PluginVersion): string {
+		const text = getTranslations().settings.betaPluginList;
+		const trackedVersionText = trackedPlugin?.version ? text.trackedVersion(trackedPlugin.version, trackedPlugin.version !== "latest") : "";
+		const incompatibleText = trackedPlugin?.isIncompatible ? text.incompatible : "";
+		const secretName = trackedPlugin?.tokenName || "";
+		const secretValue = secretName ? this.plugin.app.secretStorage.getSecret(secretName) : "";
+		const secretText = secretName && !secretValue ? text.secretMissing(secretName) : "";
+		return `${trackedVersionText}${incompatibleText}${secretText}`.trim();
+	}
+
+	private renderTrackedPluginSetting(setting: Setting, repository: string, trackedPlugin?: PluginVersion): void {
+		const text = getTranslations().settings.betaPluginList;
+		const secretName = trackedPlugin?.tokenName || "";
+		const secretValue = secretName ? this.plugin.app.secretStorage.getSecret(secretName) : "";
+		const isSecretMissing = Boolean(secretName && !secretValue);
+
+		setting.setName(createGitHubResourceLink(repository)).setDesc(this.createTrackedPluginDescriptionFragment(trackedPlugin));
+		setting.settingEl.addClass("brat-plugin-item");
+
+		setting.addExtraButton((btn: ExtraButtonComponent) => {
+			btn
+				.setIcon("copy")
+				.setTooltip(text.copyPluginIdentifier)
+				.onClick(async () => {
+					await this.copyRepoIdentifier(repository);
+				});
+		});
+
+		if (!trackedPlugin?.version || trackedPlugin.version === "latest") {
+			setting.addButton((btn: ButtonComponent) => {
+				if (isSecretMissing) {
+					btn.setIcon("sync").setTooltip(text.secretMissingTooltip(secretName)).setWarning().setDisabled(true);
+				} else {
+					btn
+						.setIcon("sync")
+						.setTooltip(text.checkAndUpdatePlugin)
+						.onClick(async () => {
+							await this.plugin.betaPlugins.updatePlugin(repository, false, true, false, trackedPlugin?.tokenName || "");
+						});
+				}
+			});
+		}
+
+		setting.addButton((btn: ButtonComponent) => {
+			btn.setIcon("edit").setTooltip(text.changeVersionAndUpdateSettings);
+
+			if (isSecretMissing) {
+				btn.setWarning();
+			}
+
+			btn.onClick(() => {
+				this.plugin.betaPlugins.displayAddNewPluginModal(
+					true,
+					true,
+					repository,
+					trackedPlugin?.version,
+					trackedPlugin?.tokenName || "",
+					() => this.update(),
+				);
+			});
+		});
+
+		setting.addButton((btn: ButtonComponent) => {
+			btn
+				.setIcon("cross")
+				.setTooltip(text.removeThisBetaPlugin)
+				.setWarning()
+				.onClick(() => {
+					if (btn.buttonEl.textContent === "") {
+						btn.setButtonText(text.confirmRemoval);
+					} else {
+						this.plugin.betaPlugins.deletePlugin(repository);
+						this.update();
+					}
+				});
+		});
+	}
+
+	private renderTrackedThemeSetting(setting: Setting, theme: ThemeInforamtion): void {
+		const text = getTranslations().settings.betaThemeList;
+		setting.setName(createGitHubResourceLink(theme.repo));
+		setting.settingEl.addClass("brat-theme-item");
+		setting.addExtraButton((btn: ExtraButtonComponent) => {
+			btn
+				.setIcon("copy")
+				.setTooltip(text.copyThemeIdentifier)
+				.onClick(async () => {
+					await this.copyRepoIdentifier(theme.repo);
+				});
+		});
+
+		setting.addButton((btn: ButtonComponent) => {
+			btn
+				.setIcon("cross")
+				.setTooltip(text.deleteThisBetaTheme)
+				.setWarning()
+				.onClick(() => {
+					if (btn.buttonEl.textContent === "") {
+						btn.setButtonText(text.confirmRemoval);
+					} else {
+						themeDelete(this.plugin, theme.repo);
+						this.update();
+					}
+				});
+		});
+	}
+
+	private renderPersonalAccessTokenSetting(setting: Setting): () => void {
+		const text = getTranslations().settings.githubPersonalAccessToken;
+		let currentTokenValue = "";
+
+		this.accessTokenSetting = new SecretComponentClass(this.plugin.app, setting.controlEl);
+
+		this.accessTokenSetting.setValue(this.plugin.settings.globalTokenName || "").onChange((secretName: string | null) => {
+			void (async () => {
+				const normalizedName = secretName?.trim() || "";
+				this.plugin.settings.globalTokenName = normalizedName;
+				await this.plugin.saveSettings();
+
+				if (normalizedName) {
+					currentTokenValue = this.plugin.app.secretStorage.getSecret(normalizedName) || "";
+					await this.validateGlobalTokenAndUpdateButton(currentTokenValue);
+				} else {
+					currentTokenValue = "";
+					await this.validateGlobalTokenAndUpdateButton("");
+				}
+			})();
+		});
+
+		if (this.plugin.settings.globalTokenName) {
+			currentTokenValue = this.plugin.app.secretStorage.getSecret(this.plugin.settings.globalTokenName) || "";
+		}
+
+		setting
+			.addExtraButton((cb: ExtraButtonComponent) => {
+				cb.setIcon("cross")
+					.setTooltip(text.clearPersonalAccessToken)
+					.onClick(async () => {
+						this.plugin.settings.globalTokenName = "";
+						await this.plugin.saveSettings();
+						this.accessTokenSetting?.setValue("");
+						currentTokenValue = "";
+						await this.validateGlobalTokenAndUpdateButton("");
+					});
+			})
+			.addButton((btn: ButtonComponent) => {
+				this.accessTokenButton = btn;
+				btn
+					.setButtonText(text.validate)
+					.setCta()
+					.onClick(async () => {
+						if (currentTokenValue) {
+							await this.validateGlobalTokenAndUpdateButton(currentTokenValue);
+						}
+					});
+			})
+			.then(() => {
+				void this.validateGlobalTokenAndUpdateButton(currentTokenValue);
+			});
+
+		return () => {
+			this.accessTokenSetting = null;
+			this.accessTokenButton = null;
+		};
+	}
+
+	private createListSearch(placeholder: string): SettingDefinitionGroup<BratSettingsKey>["search"] | undefined {
+		if (!requireApiVersion("1.13.1")) {
+			return undefined;
+		}
+
+		return {
+			placeholder,
+			match: (def: SettingDefinition, query: string) => {
+				const normalizedQuery = query.toLowerCase().trim();
+				if (normalizedQuery === "") {
+					return true;
+				}
+
+				const descriptionText = typeof def.desc === "string" ? def.desc : def.desc?.textContent || "";
+				const searchText = [def.name, descriptionText, ...(def.aliases || [])].join(" ").toLowerCase();
+				return searchText.includes(normalizedQuery);
+			},
+		};
+	}
+
+	private async validateGlobalTokenAndUpdateButton(token: string): Promise<boolean> {
+		if (!this.accessTokenButton) {
+			return false;
+		}
+
+		const text = getTranslations();
+		const validateButton = this.accessTokenButton;
+		validateButton.buttonEl.removeClass("mod-warning");
+		validateButton.setTooltip("");
+
+		if (!token) {
+			validateButton.setButtonText(text.settings.githubPersonalAccessToken.validate);
+			validateButton.setDisabled(true);
+			return false;
+		}
+
+		try {
+			const tokenInfo = await validateGitHubToken(token);
+			if (tokenInfo.validToken) {
+				validateButton.setButtonText(text.addBetaPluginModal.buttons.valid).setCta();
+				validateButton.setDisabled(true);
+				validateButton.setTooltip(this.buildTokenValidationTooltip(tokenInfo));
+				return true;
+			}
+
+			validateButton.setButtonText(text.addBetaPluginModal.buttons.invalid);
+			validateButton.buttonEl.addClass("mod-warning");
+			validateButton.setDisabled(false);
+			validateButton.setTooltip(tokenInfo.error.message);
+			return false;
+		} catch (error) {
+			console.error("Token validation error:", error);
+			validateButton.setButtonText(text.addBetaPluginModal.buttons.invalid);
+			validateButton.buttonEl.addClass("mod-warning");
+			validateButton.setDisabled(false);
+			validateButton.setTooltip("Failed to validate token");
+			return false;
+		}
+	}
+
+	private buildTokenValidationTooltip(tokenInfo: GitHubTokenInfo): string {
+		const tooltipLines: string[] = [];
+
+		if (tokenInfo.currentScopes?.length) {
+			tooltipLines.push(`Scopes: ${tokenInfo.currentScopes.join(", ")}`);
+		}
+
+		if (tokenInfo.rateLimit) {
+			tooltipLines.push(`Rate Limit: ${tokenInfo.rateLimit.remaining}/${tokenInfo.rateLimit.limit}`);
+		}
+
+		return tooltipLines.join("\n");
 	}
 }


### PR DESCRIPTION
## Why
BRAT settings were still built imperatively, which makes newer Obsidian settings features harder to use and maintain. This updates the settings UI to the declarative model while keeping compatibility with older Obsidian versions.

## What changed
- Added dual-mode settings support in `BratSettingsTab`:
  - `getSettingDefinitions()` for Obsidian 1.13+
  - existing `display()` path kept for older versions
- Migrated beta plugin/theme management to declarative list sections, including add/edit/remove flows and filtering.
- Kept the existing modal workflows and wired list actions back to them instead of introducing new UI paths.
- Updated PAT validation behavior in settings so status is reflected on the button and token details are available via tooltip.
- Localized settings-related text using existing i18n structures and routed previously hardcoded theme/modal text through translations.
- Added 1.13 declarative settings type shims in `src/types.d.ts` so the project can compile against current typings.
- Moved detailed list behavior guidance into `BRAT-DEVELOPER-GUIDE.md` and linked to it from settings with a shorter inline description.

## Notes for reviewers
- The branch includes a broad settings refactor centered in `src/ui/SettingsTab.ts`; most other file changes are wiring, i18n, and supporting types.
- I left unrelated repo-wide lint/format debt untouched and scoped this PR to the settings migration and directly related UX/docs updates.

## Verification
- `npm run build`
- Deployed and reloaded in Obsidian Sandbox via CLI during testing