### PR TITLE
feat: detect graduated beta plugins and add removal commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build
 
 # other
 **/.DS_Store
+.impeccable
 
 # AGENTS.md
 **/AGENTS.md

--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -9,7 +9,13 @@ import { addBetaPluginToList } from "../settings";
 import AddNewPluginModal from "../ui/AddNewPluginModal";
 import { isConnectedToInternet } from "../utils/internetconnection";
 import { toastMessage } from "../utils/notifications";
-import { grabReleaseFileFromRepository, grabReleaseFromRepository, isPrivateRepo, type Release } from "./githubUtils";
+import {
+	grabCommmunityPluginList,
+	grabReleaseFileFromRepository,
+	grabReleaseFromRepository,
+	isPrivateRepo,
+	type Release,
+} from "./githubUtils";
 
 /**
  * all the files needed for a plugin based on the release files are hre
@@ -26,6 +32,12 @@ interface PluginManifestEx extends PluginManifest {
 		isDesktopOnlyOriginal?: boolean;
 		minAppVersionOriginal?: string;
 	};
+}
+
+export interface GraduatedPlugin {
+	repo: string;
+	installedVersion: string;
+	stableVersion: string;
 }
 
 /**
@@ -704,6 +716,7 @@ export default class BetaPlugins {
 			}
 			toastMessage(this.plugin, msg2, 10);
 		}
+		await this.checkForOfficiallyReleasedPlugins();
 	}
 
 	/**
@@ -749,6 +762,102 @@ export default class BetaPlugins {
 				`The following incompatible plugins were forcefully installed by BRAT and may not work as expected:\n${incompatiblePluginIds.join("\n")}`,
 				30,
 			);
+		}
+	}
+
+	/**
+	 * Detects BRAT-tracked plugins that have graduated to the official Obsidian community plugin list
+	 * and have a stable (non-prerelease) release with version >= installed version.
+	 *
+	 * @returns Array of graduated plugin metadata
+	 */
+	async getOfficiallyReleasedPlugins(): Promise<GraduatedPlugin[]> {
+		const communityPlugins = await grabCommmunityPluginList(this.plugin.settings.debuggingMode);
+		if (!communityPlugins) return [];
+
+		const communityRepos = new Set(communityPlugins.map((p) => p.repo));
+
+		// Only check non-frozen plugins
+		const frozenVersions = new Map(this.plugin.settings.pluginSubListFrozenVersion.map((f) => [f.repo, f.version]));
+		const repoTokens = new Map(this.plugin.settings.pluginSubListFrozenVersion.map((f) => [f.repo, f.tokenName || ""]));
+
+		const graduated: GraduatedPlugin[] = [];
+
+		for (const repo of this.plugin.settings.pluginList) {
+			const version = frozenVersions.get(repo);
+			if (version && version !== "latest") continue;
+			if (!communityRepos.has(repo)) continue;
+
+			try {
+				// Resolve token for this repo
+				let tokenValue = "";
+				const secretName = repoTokens.get(repo) || "";
+				if (secretName) {
+					tokenValue = this.plugin.app.secretStorage.getSecret(secretName) || "";
+				} else if (this.plugin.settings.globalTokenName) {
+					tokenValue = this.plugin.app.secretStorage.getSecret(this.plugin.settings.globalTokenName) || "";
+				}
+
+				// Fetch latest stable (non-prerelease) release
+				const stableRelease = await grabReleaseFromRepository(
+					repo,
+					undefined,
+					false, // exclude prereleases
+					this.plugin.settings.debuggingMode,
+					false,
+					tokenValue || undefined,
+				);
+
+				if (!stableRelease) continue;
+
+				// Read local installed version
+				const pluginId = communityPlugins.find((p) => p.repo === repo)?.id;
+				if (!pluginId) continue;
+
+				const localManifest = this.plugin.app.plugins.manifests[pluginId];
+				if (!localManifest) continue;
+
+				const localVersion = semverCoerce(localManifest.version, { includePrerelease: true, loose: true });
+				const stableVersion = semverCoerce(stableRelease.tag_name, { includePrerelease: true, loose: true });
+
+				if (!localVersion || !stableVersion) continue;
+
+				// Stable release version >= installed version means plugin has graduated
+				if (compareVersions(stableVersion.version, localVersion.version) >= 0) {
+					graduated.push({
+						repo,
+						installedVersion: localManifest.version,
+						stableVersion: stableRelease.tag_name,
+					});
+				}
+			} catch (error) {
+				if (this.plugin.settings.debuggingMode) {
+					console.debug(`BRAT: Error checking graduation for ${repo}:`, error);
+				}
+			}
+		}
+
+		return graduated;
+	}
+
+	/**
+	 * Checks for graduated plugins and notifies the user via toast notifications.
+	 * Called at the end of every update cycle.
+	 */
+	async checkForOfficiallyReleasedPlugins(): Promise<void> {
+		try {
+			const graduated = await this.getOfficiallyReleasedPlugins();
+			for (const plugin of graduated) {
+				const msg = `${plugin.repo} has been officially released (stable: ${plugin.stableVersion}). You can remove it from BRAT and use Obsidian's built-in updates.`;
+				await this.plugin.log(msg, true);
+				toastMessage(this.plugin, msg, 30, () => {
+					window.open(`https://github.com/${plugin.repo}/releases/tag/${plugin.stableVersion}`);
+				});
+			}
+		} catch (error) {
+			if (this.plugin.settings.debuggingMode) {
+				console.debug("BRAT: Error checking for officially released plugins:", error);
+			}
 		}
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ export default class BratPlugin extends Plugin {
 	APP_NAME = "BRAT";
 	APP_ID = "obsidian42-brat";
 	settings: Settings = DEFAULT_SETTINGS;
+	settingsTab: BratSettingsTab = new BratSettingsTab(this.app, this);
 	betaPlugins = new BetaPlugins(this);
 	commands: PluginCommands = new PluginCommands(this);
 	bratApi: BratAPI = new BratAPI(this);
@@ -33,25 +34,18 @@ export default class BratPlugin extends Plugin {
 		this.loadSettings()
 			.then(async () => {
 				// Migrate tokens to SecretStorage (Obsidian 1.11.4+)
-				await migrateTokensToSecretStorage(this.app, this.settings, () =>
-					this.saveSettings(),
-				);
+				await migrateTokensToSecretStorage(this.app, this.settings, () => this.saveSettings());
 
 				this.app.workspace.onLayoutReady(() => {
-					this.addSettingTab(new BratSettingsTab(this.app, this));
+					this.addSettingTab(this.settingsTab);
 
-					this.registerObsidianProtocolHandler(
-						"brat",
-						this.obsidianProtocolHandler,
-					);
+					this.registerObsidianProtocolHandler("brat", this.obsidianProtocolHandler);
 
 					this.betaPlugins.checkIncompatiblePlugins();
 
 					if (this.settings.updateAtStartup) {
 						window.setTimeout(() => {
-							void this.betaPlugins.checkForPluginUpdatesAndInstallUpdates(
-								false,
-							);
+							void this.betaPlugins.checkForPluginUpdatesAndInstallUpdates(false);
 						}, 60000);
 					}
 					if (this.settings.updateThemesAtStartup) {
@@ -97,14 +91,7 @@ export default class BratPlugin extends Plugin {
 				let modal: AddNewPluginModal | AddNewTheme;
 				switch (which) {
 					case "plugin":
-						modal = new AddNewPluginModal(
-							this,
-							this.betaPlugins,
-							true,
-							false,
-							params[which],
-							params.version ? params.version : undefined,
-						);
+						modal = new AddNewPluginModal(this, this.betaPlugins, true, false, params[which], params.version ? params.version : undefined);
 						modal.open();
 						break;
 					case "theme":

--- a/src/ui/PluginCommands.ts
+++ b/src/ui/PluginCommands.ts
@@ -1,10 +1,8 @@
 import type {} from "@obsidian-typings/obsidian-public-1.11.4";
 import type { SettingTab } from "obsidian";
+import type { GraduatedPlugin } from "../features/BetaPlugins";
 import type { CommunityPlugin, CommunityTheme } from "../features/githubUtils";
-import {
-	grabCommmunityPluginList,
-	grabCommmunityThemesList,
-} from "../features/githubUtils";
+import { grabCommmunityPluginList, grabCommmunityThemesList } from "../features/githubUtils";
 import { themesCheckAndUpdates } from "../features/themes";
 import type BratPlugin from "../main";
 import { toastMessage } from "../utils/notifications";
@@ -30,10 +28,7 @@ export default class PluginCommands {
 			name: "Plugins: Check for updates to all beta plugins and UPDATE",
 			showInRibbon: true,
 			callback: async () => {
-				await this.plugin.betaPlugins.checkForPluginUpdatesAndInstallUpdates(
-					true,
-					false,
-				);
+				await this.plugin.betaPlugins.checkForPluginUpdatesAndInstallUpdates(true, false);
 			},
 		},
 		{
@@ -42,10 +37,7 @@ export default class PluginCommands {
 			name: "Plugins: Only check for updates to beta plugins, but don't Update",
 			showInRibbon: true,
 			callback: async () => {
-				await this.plugin.betaPlugins.checkForPluginUpdatesAndInstallUpdates(
-					true,
-					true,
-				);
+				await this.plugin.betaPlugins.checkForPluginUpdatesAndInstallUpdates(true, true);
 			},
 		},
 		{
@@ -63,9 +55,7 @@ export default class PluginCommands {
 						},
 					]),
 				);
-				const pluginList: SuggesterItem[] = Object.values(
-					this.plugin.settings.pluginList,
-				)
+				const pluginList: SuggesterItem[] = Object.values(this.plugin.settings.pluginList)
 					.filter((repo) => {
 						const frozen = frozenVersions.get(repo);
 						return !frozen?.version || frozen.version === "latest";
@@ -83,13 +73,7 @@ export default class PluginCommands {
 					const frozen = frozenVersions.get(results.info as string);
 					void this.plugin.log(msg, true);
 					toastMessage(this.plugin, `\n${msg}`, 3);
-					void this.plugin.betaPlugins.updatePlugin(
-						results.info as string,
-						false,
-						true,
-						false,
-						frozen?.tokenName,
-					);
+					void this.plugin.betaPlugins.updatePlugin(results.info as string, false, true, false, frozen?.tokenName);
 				});
 			},
 		},
@@ -99,12 +83,8 @@ export default class PluginCommands {
 			name: "Plugins: Choose a single plugin to reinstall",
 			showInRibbon: true,
 			callback: () => {
-				const pluginSubListFrozenVersionNames = new Set(
-					this.plugin.settings.pluginSubListFrozenVersion.map((f) => f.repo),
-				);
-				const pluginList: SuggesterItem[] = Object.values(
-					this.plugin.settings.pluginList,
-				)
+				const pluginSubListFrozenVersionNames = new Set(this.plugin.settings.pluginSubListFrozenVersion.map((f) => f.repo));
+				const pluginList: SuggesterItem[] = Object.values(this.plugin.settings.pluginList)
 					.filter((f) => !pluginSubListFrozenVersionNames.has(f))
 					.map((m) => {
 						return { display: m, info: m };
@@ -115,12 +95,7 @@ export default class PluginCommands {
 					const msg = `Reinstalling ${results.info as string}`;
 					toastMessage(this.plugin, `\n${msg}`, 3);
 					void this.plugin.log(msg, true);
-					void this.plugin.betaPlugins.updatePlugin(
-						results.info as string,
-						false,
-						false,
-						true,
-					);
+					void this.plugin.betaPlugins.updatePlugin(results.info as string, false, false, true);
 				});
 			},
 		},
@@ -130,19 +105,13 @@ export default class PluginCommands {
 			name: "Plugins: Restart a plugin that is already installed",
 			showInRibbon: true,
 			callback: () => {
-				const pluginList: SuggesterItem[] = Object.values(
-					this.plugin.app.plugins.manifests,
-				).map((m) => {
+				const pluginList: SuggesterItem[] = Object.values(this.plugin.app.plugins.manifests).map((m) => {
 					return { display: m.id, info: m.id };
 				});
 				const gfs = new GenericFuzzySuggester(this.plugin);
 				gfs.setSuggesterData(pluginList);
 				gfs.display((results) => {
-					toastMessage(
-						this.plugin,
-						`${results.info as string}\nPlugin reloading .....`,
-						5,
-					);
+					toastMessage(this.plugin, `${results.info as string}\nPlugin reloading .....`, 5);
 					void this.plugin.betaPlugins.reloadPlugin(results.info as string);
 				});
 			},
@@ -153,20 +122,18 @@ export default class PluginCommands {
 			name: "Plugins: Disable a plugin - toggle it off",
 			showInRibbon: true,
 			callback: () => {
-				const pluginList = this.plugin.betaPlugins
-					.getEnabledDisabledPlugins(true)
-					.map((manifest) => {
-						return {
-							display: `${manifest.name} (${manifest.id})`,
-							info: manifest.id,
-						};
-					});
+				const pluginList = this.plugin.betaPlugins.getEnabledDisabledPlugins(true).map((manifest) => {
+					return {
+						display: `${manifest.name} (${manifest.id})`,
+						info: manifest.id,
+					};
+				});
 				const gfs = new GenericFuzzySuggester(this.plugin);
 				gfs.setSuggesterData(pluginList);
 				gfs.display((results) => {
 					void this.plugin.log(`${results.display} plugin disabled`, false);
 					if (this.plugin.settings.debuggingMode) console.debug(results.info);
-					void this.plugin.app.plugins.disablePluginAndSave(results.info);
+					void this.plugin.app.plugins.disablePluginAndSave(results.info as string);
 				});
 			},
 		},
@@ -176,19 +143,17 @@ export default class PluginCommands {
 			name: "Plugins: Enable a plugin - toggle it on",
 			showInRibbon: true,
 			callback: () => {
-				const pluginList = this.plugin.betaPlugins
-					.getEnabledDisabledPlugins(false)
-					.map((manifest) => {
-						return {
-							display: `${manifest.name} (${manifest.id})`,
-							info: manifest.id,
-						};
-					});
+				const pluginList = this.plugin.betaPlugins.getEnabledDisabledPlugins(false).map((manifest) => {
+					return {
+						display: `${manifest.name} (${manifest.id})`,
+						info: manifest.id,
+					};
+				});
 				const gfs = new GenericFuzzySuggester(this.plugin);
 				gfs.setSuggesterData(pluginList);
 				gfs.display((results) => {
 					void this.plugin.log(`${results.display} plugin enabled`, false);
-					void this.plugin.app.plugins.enablePluginAndSave(results.info);
+					void this.plugin.app.plugins.enablePluginAndSave(results.info as string);
 				});
 			},
 		},
@@ -198,18 +163,12 @@ export default class PluginCommands {
 			name: "Plugins: Open the GitHub repository for a plugin",
 			showInRibbon: true,
 			callback: async () => {
-				const communityPlugins = await grabCommmunityPluginList(
-					this.plugin.settings.debuggingMode,
-				);
+				const communityPlugins = await grabCommmunityPluginList(this.plugin.settings.debuggingMode);
 				if (communityPlugins) {
-					const communityPluginList: SuggesterItem[] = Object.values(
-						communityPlugins,
-					).map((p: CommunityPlugin) => {
+					const communityPluginList: SuggesterItem[] = Object.values(communityPlugins).map((p: CommunityPlugin) => {
 						return { display: `Plugin: ${p.name}  (${p.repo})`, info: p.repo };
 					});
-					const bratList: SuggesterItem[] = Object.values(
-						this.plugin.settings.pluginList,
-					).map((p) => {
+					const bratList: SuggesterItem[] = Object.values(this.plugin.settings.pluginList).map((p) => {
 						return { display: `BRAT: ${p}`, info: p };
 					});
 					for (const si of communityPluginList) {
@@ -218,8 +177,7 @@ export default class PluginCommands {
 					const gfs = new GenericFuzzySuggester(this.plugin);
 					gfs.setSuggesterData(bratList);
 					gfs.display((results) => {
-						if (results.info)
-							window.open(`https://github.com/${results.info as string}`);
+						if (results.info) window.open(`https://github.com/${results.info as string}`);
 					});
 				}
 			},
@@ -230,34 +188,25 @@ export default class PluginCommands {
 			name: "Plugins: Open the community page for a plugin",
 			showInRibbon: true,
 			callback: async () => {
-				const communityPlugins = await grabCommmunityPluginList(
-					this.plugin.settings.debuggingMode,
-				);
+				const communityPlugins = await grabCommmunityPluginList(this.plugin.settings.debuggingMode);
 				if (!communityPlugins) {
-					toastMessage(
-						this.plugin,
-						"Could not load the Obsidian community plugin list.",
-						5,
-					);
+					toastMessage(this.plugin, "Could not load the Obsidian community plugin list.", 5);
 					return;
 				}
 
-				const pluginByRepo = new Map(
-					communityPlugins.map((plugin) => [plugin.repo, plugin]),
-				);
+				const pluginByRepo = new Map(communityPlugins.map((plugin) => [plugin.repo, plugin]));
 				const seenPluginIds = new Set<string>();
 
-				const prioritizedBratPlugins: SuggesterItem[] =
-					this.plugin.settings.pluginList
-						.map((repo) => pluginByRepo.get(repo))
-						.filter((plugin): plugin is CommunityPlugin => Boolean(plugin))
-						.map((plugin) => {
-							seenPluginIds.add(plugin.id);
-							return {
-								display: `BRAT: ${plugin.name} (${plugin.id})`,
-								info: plugin.id,
-							};
-						});
+				const prioritizedBratPlugins: SuggesterItem[] = this.plugin.settings.pluginList
+					.map((repo) => pluginByRepo.get(repo))
+					.filter((plugin): plugin is CommunityPlugin => Boolean(plugin))
+					.map((plugin) => {
+						seenPluginIds.add(plugin.id);
+						return {
+							display: `BRAT: ${plugin.name} (${plugin.id})`,
+							info: plugin.id,
+						};
+					});
 
 				const communityPluginList: SuggesterItem[] = communityPlugins
 					.filter((plugin) => !seenPluginIds.has(plugin.id))
@@ -269,15 +218,10 @@ export default class PluginCommands {
 					});
 
 				const gfs = new GenericFuzzySuggester(this.plugin);
-				gfs.setSuggesterData([
-					...prioritizedBratPlugins,
-					...communityPluginList,
-				]);
+				gfs.setSuggesterData([...prioritizedBratPlugins, ...communityPluginList]);
 				gfs.display((results) => {
 					if (results.info) {
-						window.open(
-							`https://obsidian.md/plugins?id=${encodeURIComponent(results.info as string)}`,
-						);
+						window.open(`https://obsidian.md/plugins?id=${encodeURIComponent(results.info as string)}`);
 					}
 				});
 			},
@@ -288,20 +232,15 @@ export default class PluginCommands {
 			name: "Themes: Open the GitHub repository for a theme (appearance)",
 			showInRibbon: true,
 			callback: async () => {
-				const communityTheme = await grabCommmunityThemesList(
-					this.plugin.settings.debuggingMode,
-				);
+				const communityTheme = await grabCommmunityThemesList(this.plugin.settings.debuggingMode);
 				if (communityTheme) {
-					const communityThemeList: SuggesterItem[] = Object.values(
-						communityTheme,
-					).map((p: CommunityTheme) => {
+					const communityThemeList: SuggesterItem[] = Object.values(communityTheme).map((p: CommunityTheme) => {
 						return { display: `Theme: ${p.name}  (${p.repo})`, info: p.repo };
 					});
 					const gfs = new GenericFuzzySuggester(this.plugin);
 					gfs.setSuggesterData(communityThemeList);
 					gfs.display((results) => {
-						if (results.info)
-							window.open(`https://github.com/${results.info as string}`);
+						if (results.info) window.open(`https://github.com/${results.info as string}`);
 					});
 				}
 			},
@@ -313,15 +252,11 @@ export default class PluginCommands {
 			showInRibbon: true,
 			callback: () => {
 				const settings = this.plugin.app.setting;
-				const listOfPluginSettingsTabs: SuggesterItem[] = Object.values(
-					settings.pluginTabs,
-				).map((t) => {
+				const listOfPluginSettingsTabs: SuggesterItem[] = Object.values(settings.pluginTabs).map((t) => {
 					return { display: `Plugin: ${t.name}`, info: t.id };
 				});
 				const gfs = new GenericFuzzySuggester(this.plugin);
-				const listOfCoreSettingsTabs: SuggesterItem[] = Object.values(
-					settings.settingTabs,
-				).map((t) => {
+				const listOfCoreSettingsTabs: SuggesterItem[] = Object.values(settings.settingTabs).map((t) => {
 					return { display: `Core: ${t.name}`, info: t.id };
 				});
 				for (const si of listOfPluginSettingsTabs) {
@@ -330,7 +265,7 @@ export default class PluginCommands {
 				gfs.setSuggesterData(listOfCoreSettingsTabs);
 				gfs.display((results) => {
 					settings.open();
-					settings.openTabById(results.info);
+					settings.openTabById(results.info as string);
 				});
 			},
 		},
@@ -353,6 +288,74 @@ export default class PluginCommands {
 			},
 		},
 		{
+			id: "removeGraduatedFromBrat",
+			icon: "BratIcon",
+			name: "Plugins: Remove a graduated plugin from BRAT (keep installed)",
+			showInRibbon: true,
+			callback: async () => {
+				const graduated = await this.plugin.betaPlugins.getOfficiallyReleasedPlugins();
+				if (graduated.length === 0) {
+					toastMessage(this.plugin, "No graduated plugins found. All BRAT plugins are still in beta.", 5);
+					return;
+				}
+				const pluginList: SuggesterItem[] = graduated.map((p: GraduatedPlugin) => ({
+					display: `${p.repo} (installed: ${p.installedVersion}, stable: ${p.stableVersion})`,
+					info: p.repo,
+				}));
+				const gfs = new GenericFuzzySuggester(this.plugin);
+				gfs.setSuggesterData(pluginList);
+				gfs.display((results) => {
+					const repo = results.info as string;
+					this.plugin.betaPlugins.deletePlugin(repo);
+					this.plugin.settingsTab.update();
+					toastMessage(this.plugin, `${repo} removed from BRAT. Obsidian will now manage updates via the community plugin list.`, 10);
+				});
+			},
+		},
+		{
+			id: "updateGraduatedToStableAndRemove",
+			icon: "BratIcon",
+			name: "Plugins: Update a graduated plugin to stable release and remove from BRAT",
+			showInRibbon: true,
+			callback: async () => {
+				const graduated = await this.plugin.betaPlugins.getOfficiallyReleasedPlugins();
+				if (graduated.length === 0) {
+					toastMessage(this.plugin, "No graduated plugins found. All BRAT plugins are still in beta.", 5);
+					return;
+				}
+				const pluginList: SuggesterItem[] = graduated.map((p: GraduatedPlugin) => ({
+					display: `${p.repo} (installed: ${p.installedVersion} → stable: ${p.stableVersion})`,
+					info: p.repo,
+				}));
+				const gfs = new GenericFuzzySuggester(this.plugin);
+				gfs.setSuggesterData(pluginList);
+				gfs.display((results) => {
+					void (async () => {
+						const repo = results.info as string;
+						const match = graduated.find((g) => g.repo === repo);
+						if (!match) return;
+						// Install stable release (non-beta manifest, specific version)
+						const success = await this.plugin.betaPlugins.addPlugin(
+							repo,
+							false,
+							false,
+							false,
+							match.stableVersion,
+							true, // force reinstall
+							true, // enable after install
+						);
+						if (success) {
+							this.plugin.betaPlugins.deletePlugin(repo);
+							this.plugin.settingsTab.update();
+							toastMessage(this.plugin, `${repo} updated to stable ${match.stableVersion} and removed from BRAT.`, 10);
+						} else {
+							toastMessage(this.plugin, `Failed to install stable release for ${repo}.`, 10);
+						}
+					})();
+				});
+			},
+		},
+		{
 			id: "allCommands",
 			icon: "BratIcon",
 			name: "All Commands list",
@@ -366,15 +369,12 @@ export default class PluginCommands {
 	ribbonDisplayCommands(): void {
 		const bratCommandList: SuggesterItem[] = [];
 		for (const cmd of this.bratCommands) {
-			if (cmd.showInRibbon)
-				bratCommandList.push({ display: cmd.name, info: cmd.callback });
+			if (cmd.showInRibbon) bratCommandList.push({ display: cmd.name, info: cmd.callback });
 		}
 		const gfs = new GenericFuzzySuggester(this.plugin);
 		const settings = this.plugin.app.setting;
 
-		const listOfCoreSettingsTabs: SuggesterItem[] = Object.values(
-			settings.settingTabs,
-		).map((t: SettingTab) => {
+		const listOfCoreSettingsTabs: SuggesterItem[] = Object.values(settings.settingTabs).map((t: SettingTab) => {
 			return {
 				display: `Core: ${t.name}`,
 				info: () => {
@@ -383,9 +383,7 @@ export default class PluginCommands {
 				},
 			};
 		});
-		const listOfPluginSettingsTabs: SuggesterItem[] = Object.values(
-			settings.pluginTabs,
-		).map((t: SettingTab) => {
+		const listOfPluginSettingsTabs: SuggesterItem[] = Object.values(settings.pluginTabs).map((t: SettingTab) => {
 			return {
 				display: `Plugin: ${t.name}`,
 				info: () => {


### PR DESCRIPTION
## Motivation

When a beta plugin tracked by BRAT gets officially released to the Obsidian community plugin list, users have no way to know. They keep running the beta version indefinitely, missing out on the stable update channel and cluttering their BRAT list with plugins that no longer need beta tracking.

This addresses [issue #61](https://github.com/TfTHacker/obsidian42-brat/issues/61).

## Approach

**Detection logic** -- a new `getOfficiallyReleasedPlugins()` method cross-references BRAT-tracked plugins against the official `community-plugins.json` list, then fetches the latest stable (non-prerelease) GitHub release for each match. If the stable version >= the installed version, the plugin is flagged as "graduated."

**Auto-notification** -- `checkForOfficiallyReleasedPlugins()` runs at the end of every update cycle and toasts the user with a link to the release page for each graduated plugin.

**Two new commands:**

- "Remove a graduated plugin from BRAT (keep installed)" -- removes BRAT tracking; Obsidian's native update channel takes over.
- "Update a graduated plugin to stable release and remove from BRAT" -- installs the stable release, then removes BRAT tracking.

## Design decisions

- Dual-condition check (community list AND stable release) prevents false positives from plugins that are listed but have no stable release yet.
- Non-destructive: detection only notifies. Removal requires explicit user action via command palette.
- Respects existing token infrastructure (per-repo and global tokens via SecretStorage).

## Files changed

- `src/features/BetaPlugins.ts` -- graduation detection + update cycle wiring
- `src/ui/PluginCommands.ts` -- two new command entries

Closes https://github.com/TfTHacker/obsidian42-brat/issues/61