### PR TITLE
fix(security): reject path traversal in plugin id / theme name before writing

### DIFF
--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -9,6 +9,7 @@ import { addBetaPluginToList } from "../settings";
 import AddNewPluginModal from "../ui/AddNewPluginModal";
 import { isConnectedToInternet } from "../utils/internetconnection";
 import { toastMessage } from "../utils/notifications";
+import { isSafeVaultFolderName } from "../utils/utils";
 import {
 	grabCommmunityPluginList,
 	grabReleaseFileFromRepository,
@@ -387,6 +388,17 @@ export default class BetaPlugins {
 
 			if (!Object.hasOwn(primaryManifest, "version")) {
 				const msg = `${repositoryPath}\nThe manifest.json file in the latest release or pre-release of the repository does not have a version number in the file. This plugin cannot be installed.`;
+				await this.plugin.log(msg, true);
+				toastMessage(this.plugin, msg, noticeTimeout);
+				return false;
+			}
+
+			// Security: the plugin id is taken verbatim from the remote manifest and is
+			// later concatenated into the install path (.obsidian/plugins/<id>). Reject
+			// ids containing path separators or ".." so a malicious repo cannot escape
+			// the plugins folder and overwrite other plugins or vault files.
+			if (!isSafeVaultFolderName(primaryManifest.id)) {
+				const msg = `${repositoryPath}\nThe manifest.json declares an unsafe plugin id ("${primaryManifest.id}"). This plugin cannot be installed.`;
 				await this.plugin.log(msg, true);
 				toastMessage(this.plugin, msg, noticeTimeout);
 				return false;

--- a/src/features/themes.ts
+++ b/src/features/themes.ts
@@ -5,6 +5,7 @@ import type BratPlugin from "../main";
 import { addBetaThemeToList, updateBetaThemeLastUpdateChecksum } from "../settings";
 import { isConnectedToInternet } from "../utils/internetconnection";
 import { toastMessage } from "../utils/notifications";
+import { isSafeVaultFolderName } from "../utils/utils";
 import { checksumForString, grabChecksumOfThemeCssFile, grabCommmunityThemeCssFile, grabCommmunityThemeManifestFile } from "./githubUtils";
 
 /**
@@ -34,7 +35,25 @@ export const themeSave = async (plugin: BratPlugin, cssGithubRepository: string,
 		return false;
 	}
 
-	const manifestInfo = (await JSON.parse(themeManifest)) as ThemeManifest;
+	let manifestInfo: ThemeManifest;
+	try {
+		manifestInfo = JSON.parse(themeManifest) as ThemeManifest;
+	} catch (error) {
+		console.error("BRAT - invalid theme manifest.json", cssGithubRepository, error);
+		toastMessage(plugin, text.noManifestFile);
+		return false;
+	}
+
+	// Security: the theme name comes verbatim from the remote manifest and is
+	// concatenated into the install path (.obsidian/themes/<name>). Reject names
+	// containing path separators or ".." so a malicious theme cannot escape the
+	// themes folder and overwrite other files.
+	if (!isSafeVaultFolderName(manifestInfo.name)) {
+		const msg = text.unsafeThemeName(cssGithubRepository, manifestInfo.name);
+		console.error("BRAT - unsafe theme name", cssGithubRepository, manifestInfo.name);
+		toastMessage(plugin, msg);
+		return false;
+	}
 
 	const themeTargetFolderPath = normalizePath(themesRootPath(plugin) + manifestInfo.name);
 

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -169,6 +169,8 @@ export const de = {
 			"Im Stammverzeichnis dieses Repositorys gibt es keine Datei theme.css oder theme-beta.css, daher kann kein Theme installiert werden.",
 		noManifestFile:
 			"Im Stammverzeichnis dieses Repositorys gibt es keine Datei manifest.json, daher kann das Theme nicht installiert werden.",
+		unsafeThemeName: (repository: string, themeName: string): string =>
+			`${repository}: Das Theme-Manifest deklariert einen unsicheren Namen („${themeName}“), daher kann dieses Theme nicht installiert werden.`,
 		installed: (themeName: string, repository: string): string => `Theme ${themeName} wurde aus ${repository} installiert. `,
 		updated: (themeName: string, repository: string): string => `Theme ${themeName} wurde aus ${repository} aktualisiert.`,
 		removed: (repository: string): string =>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -161,6 +161,8 @@ export const en = {
 	themeMessages: {
 		noThemeCssFile: "There is no theme.css or theme-beta.css file in the root path of this repository, so there is no theme to install.",
 		noManifestFile: "There is no manifest.json file in the root path of this repository, so theme cannot be installed.",
+		unsafeThemeName: (repository: string, themeName: string): string =>
+			`${repository}: the theme manifest declares an unsafe name ("${themeName}"), so this theme cannot be installed.`,
 		installed: (themeName: string, repository: string): string => `${themeName} theme installed from ${repository}. `,
 		updated: (themeName: string, repository: string): string => `${themeName} theme updated from ${repository}.`,
 		removed: (repository: string): string =>

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -165,6 +165,8 @@ export const ja = {
 	themeMessages: {
 		noThemeCssFile: "このリポジトリのルートパスには theme.css または theme-beta.css がないため、インストールできるテーマがありません。",
 		noManifestFile: "このリポジトリのルートパスには manifest.json がないため、テーマをインストールできません。",
+		unsafeThemeName: (repository: string, themeName: string): string =>
+			`${repository}: テーマの manifest に安全でない名前（「${themeName}」）が指定されているため、このテーマはインストールできません。`,
 		installed: (themeName: string, repository: string): string => `${repository} からテーマ ${themeName} をインストールしました。`,
 		updated: (themeName: string, repository: string): string => `${repository} からテーマ ${themeName} を更新しました。`,
 		removed: (repository: string): string =>

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -160,6 +160,8 @@ export const zhCn = {
 	themeMessages: {
 		noThemeCssFile: "这个仓库的根目录里没有 theme.css 或 theme-beta.css 文件，因此没有可安装的主题。",
 		noManifestFile: "这个仓库的根目录里没有 manifest.json 文件，因此无法安装该主题。",
+		unsafeThemeName: (repository: string, themeName: string): string =>
+			`${repository}：主题 manifest 声明了不安全的名称（“${themeName}”），因此无法安装此主题。`,
 		installed: (themeName: string, repository: string): string => `已从 ${repository} 安装主题 ${themeName}。`,
 		updated: (themeName: string, repository: string): string => `已从 ${repository} 更新主题 ${themeName}。`,
 		removed: (repository: string): string =>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,22 @@
+/**
+ * Validates a plugin id or theme folder name that will be concatenated into a
+ * filesystem path inside the vault (e.g. `.obsidian/plugins/<id>`). These values
+ * come from a remote, attacker-controllable manifest.json, and Obsidian's
+ * `normalizePath` does not strip `..`, so an unchecked value like
+ * `"../../.obsidian/plugins/other"` can escape the intended folder and overwrite
+ * unrelated files. Returns true only for plain identifiers with no path
+ * separators or `..` segments.
+ */
+export function isSafeVaultFolderName(name: string): boolean {
+	if (!name || name.length > 100) return false;
+	// Allow only letters, numbers, spaces, dot, underscore and hyphen. This
+	// excludes "/" and "\", so no path separators can slip through.
+	if (!/^[A-Za-z0-9 ._-]+$/.test(name)) return false;
+	// Reject "." / ".." and any embedded parent-directory traversal.
+	if (name === "." || name.includes("..")) return false;
+	return true;
+}
+
 export function createGitHubResourceLink(
 	githubResource: string,
 	optionalText?: string,


### PR DESCRIPTION
### fix(security): reject path-traversal in plugin id / theme name before writing

A beta plugin/theme manifest is fetched from an arbitrary GitHub repo, and its
id (plugins) or name (themes) was concatenated verbatim into the install path.
Obsidian normalizePath does not strip "..", so a manifest with e.g.
"id": "../../.obsidian/plugins/other" could escape the intended folder and
overwrite unrelated plugins/files in the vault (the user consents to installing
one named repo, not to clobbering others).

- Add isSafeVaultFolderName() (utils): allows only [A-Za-z0-9 ._-], rejects
  path separators and any ".." segment.
- Validate primaryManifest.id in addPlugin() before any path use (covers install
  and update paths, which all route through addPlugin).
- Validate manifest name in themeSave() before building the theme path, and wrap
  the previously-uncaught JSON.parse of the remote theme manifest in try/catch.
- Add the unsafeThemeName message to all four locales.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
📌 Part of a 9-PR series from a combined code + security review — tracking issue #199.

**Related PRs:** #190 (security · path traversal) · #191 (settings-tab + unload) · #192 (correctness) · #193 (error-handling) · #194 (modal UX + settings polish) · #195 (cleanup) · #196 (migration path) · #197 (addPlugin options) · #198 (githubUtils cleanup)