### PR TITLE
fix: register settings tab synchronously (Options button) + clean up on unload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,14 +31,20 @@ export default class BratPlugin extends Plugin {
 			this.commands.ribbonDisplayCommands();
 		});
 
+		// Register the settings tab synchronously during onload so the "Options"
+		// button shows up immediately on first enable. If this is deferred (into a
+		// promise chain or onLayoutReady), Obsidian's Community Plugins view paints
+		// before the tab exists and the button only appears after a disable/enable.
+		// settings is already initialized to DEFAULT_SETTINGS, and display() runs
+		// lazily when the user opens the tab, so no loaded data is required here.
+		this.addSettingTab(this.settingsTab);
+
 		this.loadSettings()
 			.then(async () => {
 				// Migrate tokens to SecretStorage (Obsidian 1.11.4+)
 				await migrateTokensToSecretStorage(this.app, this.settings, () => this.saveSettings());
 
 				this.app.workspace.onLayoutReady(() => {
-					this.addSettingTab(this.settingsTab);
-
 					this.registerObsidianProtocolHandler("brat", this.obsidianProtocolHandler);
 
 					this.betaPlugins.checkIncompatiblePlugins();

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,18 +50,27 @@ export default class BratPlugin extends Plugin {
 					this.betaPlugins.checkIncompatiblePlugins();
 
 					if (this.settings.updateAtStartup) {
-						window.setTimeout(() => {
-							void this.betaPlugins.checkForPluginUpdatesAndInstallUpdates(false);
-						}, 60000);
+						// registerInterval so the timer is cancelled if BRAT unloads before it
+						// fires (clearInterval also clears setTimeout ids), avoiding update
+						// checks running against a dead plugin instance.
+						this.registerInterval(
+							window.setTimeout(() => {
+								void this.betaPlugins.checkForPluginUpdatesAndInstallUpdates(false);
+							}, 60000),
+						);
 					}
 					if (this.settings.updateThemesAtStartup) {
-						window.setTimeout(() => {
-							void themesCheckAndUpdates(this, false);
-						}, 120000);
+						this.registerInterval(
+							window.setTimeout(() => {
+								void themesCheckAndUpdates(this, false);
+							}, 120000),
+						);
 					}
-					window.setTimeout(() => {
-						window.bratAPI = this.bratApi;
-					}, 500);
+					this.registerInterval(
+						window.setTimeout(() => {
+							window.bratAPI = this.bratApi;
+						}, 500),
+					);
 				});
 			})
 			.catch((error: unknown) => {
@@ -75,6 +84,8 @@ export default class BratPlugin extends Plugin {
 
 	onunload(): void {
 		console.debug(`unloading ${this.APP_NAME}`);
+		// Remove the global API handle so it does not dangle after unload.
+		delete window.bratAPI;
 	}
 
 	async loadSettings(): Promise<void> {


### PR DESCRIPTION
### fix: register settings tab synchronously so Options button shows on first enable

addSettingTab() was deferred inside loadSettings().then() and onLayoutReady(),
so onload() returned before the tab was registered. Obsidian paints the
Community Plugins detail view right after onload() returns, so the "Options"
button was missing on first enable and only appeared after a disable/enable
re-render. Register the tab synchronously in onload() (settings is already
initialized to DEFAULT_SETTINGS and display() runs lazily), leaving the token
migration, protocol handler, and startup update checks deferred as before.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

### fix: clean up startup timers and window.bratAPI on unload

The startup update-check timeouts and the window.bratAPI global were never
cancelled/removed on unload, so disabling BRAT within ~2 minutes of startup
still ran update/install logic against a dead plugin instance, and window.bratAPI
dangled forever. Wrap the timeouts in registerInterval (clearInterval also
cancels setTimeout ids) so Obsidian cancels them on unload, and delete
window.bratAPI in onunload.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
📌 Part of a 9-PR series from a combined code + security review — tracking issue #199.

**Related PRs:** #190 (security · path traversal) · #191 (settings-tab + unload) · #192 (correctness) · #193 (error-handling) · #194 (modal UX + settings polish) · #195 (cleanup) · #196 (migration path) · #197 (addPlugin options) · #198 (githubUtils cleanup)