### PR TITLE
fix: correctness bugs in reinstall command, modals, and update flow

### DIFF
--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -550,12 +550,18 @@ export default class BetaPlugins {
 					localManifestContents = await this.plugin.app.vault.adapter.read(`${pluginTargetFolderPath}manifest.json`);
 				} catch (e) {
 					if ((e as ErrnoType).errno === -4058 || (e as ErrnoType).errno === -2) {
-						// file does not exist, try installing the plugin
-						await this.addPlugin(repositoryPath, false, usingBetaManifest, false, specifyVersion, false, enableAfterInstall, secretName);
+						// file does not exist, try installing the plugin (seeIfUpdatedOnly must
+						// be false here so the plugin is actually installed, not just checked)
+						await this.addPlugin(repositoryPath, false, false, false, specifyVersion, false, enableAfterInstall, secretName);
 						// even though failed, return true since install will be attempted
 						return true;
 					}
+					// Any other read error (permissions, unexpected adapter error, or a mobile
+					// adapter error with no errno): bail out instead of falling through to
+					// JSON.parse("") below, which would throw a SyntaxError surfaced as a
+					// generic "Unknown error".
 					console.error("BRAT - Local Manifest Load", primaryManifest.id, JSON.stringify(e, null, 2));
+					return false;
 				}
 
 				if (specifyVersion !== "" && specifyVersion !== "latest") {

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -229,6 +229,9 @@ export default class AddNewPluginModal extends Modal {
 										this.cancelButton?.setDisabled(true);
 										this.versionSetting?.setDisabled(true);
 										void this.submitForm();
+										// Return so we don't also re-fetch versions, which would re-enable the
+										// version setting and mutate this.version while the install is in flight.
+										return;
 									}
 
 									// Populate version dropdown

--- a/src/ui/AddNewTheme.ts
+++ b/src/ui/AddNewTheme.ts
@@ -110,8 +110,7 @@ export default class AddNewTheme extends Modal {
 
 	onClose(): void {
 		if (this.openSettingsTabAfterwards) {
-			// @ts-expect-error
-			this.plugin.app.setting.openTab();
+			this.plugin.app.setting.open();
 			this.plugin.app.setting.openTabById(this.plugin.APP_ID);
 		}
 	}

--- a/src/ui/PluginCommands.ts
+++ b/src/ui/PluginCommands.ts
@@ -83,9 +83,14 @@ export default class PluginCommands {
 			name: "Plugins: Choose a single plugin to reinstall",
 			showInRibbon: true,
 			callback: () => {
-				const pluginSubListFrozenVersionNames = new Set(this.plugin.settings.pluginSubListFrozenVersion.map((f) => f.repo));
+				// Only exclude plugins pinned to a specific frozen version. Plugins tracking
+				// "latest" are also stored in pluginSubListFrozenVersion, so excluding the whole
+				// list (as before) left this reinstall picker empty for every plugin.
+				const frozenVersionRepos = new Set(
+					this.plugin.settings.pluginSubListFrozenVersion.filter((f) => f.version && f.version !== "latest").map((f) => f.repo),
+				);
 				const pluginList: SuggesterItem[] = Object.values(this.plugin.settings.pluginList)
-					.filter((f) => !pluginSubListFrozenVersionNames.has(f))
+					.filter((f) => !frozenVersionRepos.has(f))
 					.map((m) => {
 						return { display: m, info: m };
 					});

--- a/src/ui/VersionSuggestModal.ts
+++ b/src/ui/VersionSuggestModal.ts
@@ -37,9 +37,4 @@ export class VersionSuggestModal extends SuggestModal<ReleaseVersion> {
 	onChooseSuggestion(version: ReleaseVersion) {
 		this.onChoose(version.version);
 	}
-
-	onNoSuggestion(): void {
-		this.onChoose(this.selected ? this.selected : "");
-		this.close();
-	}
 }


### PR DESCRIPTION
### fix: correctness bugs in reinstall command, modals, and update flow

- PluginCommands: the "reinstall a single plugin" picker excluded every repo in
  pluginSubListFrozenVersion, but plugins tracking "latest" are stored there too,
  so the list was always empty. Exclude only truly frozen (specific-version) repos.
- BetaPlugins: the recursive addPlugin() call in the local-manifest-missing path
  passed usingBetaManifest into the seeIfUpdatedOnly parameter; pass false so the
  plugin is actually installed.
- BetaPlugins: a local manifest read error other than ENOENT fell through to
  JSON.parse("") and threw a SyntaxError surfaced as "Unknown error"; return false
  on unexpected read errors instead.
- AddNewPluginModal: Enter-to-submit did not return, so it also re-fetched versions
  mid-install, re-enabling the version setting and mutating this.version. Return
  after submitting.
- AddNewTheme.onClose: used the wrong (ts-expect-error-suppressed) setting.openTab()
  instead of setting.open(), matching AddNewPluginModal.
- VersionSuggestModal: onNoSuggestion fired onChoose()+close() on any zero-match
  query, kicking the user out mid-typing. Remove the override.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
📌 Part of a 9-PR series from a combined code + security review — tracking issue #199.

**Related PRs:** #190 (security · path traversal) · #191 (settings-tab + unload) · #192 (correctness) · #193 (error-handling) · #194 (modal UX + settings polish) · #195 (cleanup) · #196 (migration path) · #197 (addPlugin options) · #198 (githubUtils cleanup)