### PR TITLE
fix: error-handling gaps in theme updates, install toasts, logging, errors

### DIFF
--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -373,7 +373,10 @@ export default class BetaPlugins {
 
 			const noticeTimeout = 10;
 			// attempt to get manifest-beta.json
-			let primaryManifest = await this.validateRepository(repositoryPath, true, true, specifyVersion, tokenValue);
+			// Don't report issues on the beta-manifest probe: most plugins have no beta
+			// manifest, so a failure here is expected and would produce a spurious toast
+			// on top of the regular-manifest attempt below.
+			let primaryManifest = await this.validateRepository(repositoryPath, true, false, specifyVersion, tokenValue);
 			const usingBetaManifest: boolean = !!primaryManifest;
 			// attempt to get manifest.json
 			if (!usingBetaManifest) primaryManifest = await this.validateRepository(repositoryPath, false, true, specifyVersion, tokenValue);

--- a/src/features/themes.ts
+++ b/src/features/themes.ts
@@ -34,7 +34,7 @@ export const themeSave = async (plugin: BratPlugin, cssGithubRepository: string,
 		return false;
 	}
 
-	const manifestInfo = (await JSON.parse(themeManifest)) as ThemeManifest;
+	const manifestInfo = JSON.parse(themeManifest) as ThemeManifest;
 
 	const themeTargetFolderPath = normalizePath(themesRootPath(plugin) + manifestInfo.name);
 
@@ -82,12 +82,18 @@ export const themesCheckAndUpdates = async (plugin: BratPlugin, showInfo: boolea
 	await plugin.log(msg1, true);
 	if (showInfo && plugin.settings.notificationsEnabled) newNotice = new Notice(`BRAT\n${msg1}`, 30000);
 	for (const t of plugin.settings.themesList) {
-		// first test to see if theme-beta.css exists
-		let lastUpdateOnline = await grabChecksumOfThemeCssFile(t.repo, true, plugin.settings.debuggingMode);
-		// if theme-beta.css does NOT exist, try to get theme.css
-		if (lastUpdateOnline === "0") lastUpdateOnline = await grabChecksumOfThemeCssFile(t.repo, false, plugin.settings.debuggingMode);
-		console.debug("BRAT: lastUpdateOnline", lastUpdateOnline);
-		if (lastUpdateOnline !== t.lastUpdate) await themeSave(plugin, t.repo, false);
+		// Guard each theme independently so one bad manifest/repo doesn't abort the
+		// whole update loop (and leave the "STARTED" notice hanging).
+		try {
+			// first test to see if theme-beta.css exists
+			let lastUpdateOnline = await grabChecksumOfThemeCssFile(t.repo, true, plugin.settings.debuggingMode);
+			// if theme-beta.css does NOT exist, try to get theme.css
+			if (lastUpdateOnline === "0") lastUpdateOnline = await grabChecksumOfThemeCssFile(t.repo, false, plugin.settings.debuggingMode);
+			console.debug("BRAT: lastUpdateOnline", lastUpdateOnline);
+			if (lastUpdateOnline !== t.lastUpdate) await themeSave(plugin, t.repo, false);
+		} catch (error) {
+			console.error("BRAT - theme update failed", t.repo, error);
+		}
 	}
 	const msg2 = "Checking for beta theme updates COMPLETED";
 	await plugin.log(msg2, true);

--- a/src/utils/GitHubAPIErrors.ts
+++ b/src/utils/GitHubAPIErrors.ts
@@ -24,10 +24,15 @@ export class GitHubResponseError extends Error {
 	public readonly headers: GitHubResponseHeaders;
 
 	constructor(error: Error) {
-		super(`GitHub API error ${error}: ${error.message}`);
+		// The old super() message ("GitHub API error <stringified error>: ...") was
+		// immediately overwritten by this.message below, so it never surfaced. Pass the
+		// real message straight through.
+		super(error.message);
 
+		// message is a declared class field, so it must be assigned here (a field with no
+		// initializer would otherwise reset the Error-set message to undefined).
 		this.message = error.message;
-		const ghError = error as GitHubResponseError;
+		const ghError = error as Partial<GitHubResponseError>;
 		this.status = ghError.status ?? 400;
 		this.headers = ghError.headers ?? {};
 

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -59,7 +59,7 @@ export async function logger(
 			? (window.require("os") as { hostname: () => string })
 			: null;
 		const machineName = Platform.isDesktop ? os?.hostname() : "MOBILE";
-		const output = `${dateOutput} ${machineName} ${textToLog.replace("\n", " ")}\n`;
+		const output = `${dateOutput} ${machineName} ${textToLog.replace(/\n/g, " ")}\n`;
 
 		const file = plugin.app.vault.getAbstractFileByPath(fileName);
 		if (!(file instanceof TFile)) {


### PR DESCRIPTION
### fix: error-handling gaps in theme updates, install toasts, logging, errors

- themes: wrap each theme in themesCheckAndUpdates in try/catch so one bad
  manifest/repo no longer aborts the whole loop (leaving the "STARTED" notice
  hanging); drop the pointless await on the synchronous JSON.parse.
- BetaPlugins: the beta-manifest probe ran with reportIssues=true, so repos with
  no beta manifest (the common case) produced a spurious error toast on top of the
  regular-manifest attempt. Probe quietly (reportIssues=false).
- logging: replace only rewrote the first newline; use /\\n/g so multi-line log
  messages stay on one line.
- GitHubAPIErrors: the GitHubResponseError super() message was dead (immediately
  overwritten) and stringified the whole error; pass error.message through and use
  a Partial cast for the status/headers lookup.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
📌 Part of a 9-PR series from a combined code + security review — tracking issue #199.

**Related PRs:** #190 (security · path traversal) · #191 (settings-tab + unload) · #192 (correctness) · #193 (error-handling) · #194 (modal UX + settings polish) · #195 (cleanup) · #196 (migration path) · #197 (addPlugin options) · #198 (githubUtils cleanup)