### PR TITLE
feat: add-plugin modal UX, declarative settings polish, and SVG README wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](media/brat.jpg)
+![brat](media/brat.svg)
 
 # BRAT - Beta Reviewers Auto-update Tester
 

--- a/media/brat.svg
+++ b/media/brat.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 250" width="1024" height="250" role="img" aria-label="brat">
+  <rect width="1024" height="250" fill="#8ACE00"/>
+  <text x="512" y="168" fill="#1a1a1a"
+        font-family="Arial, Helvetica, sans-serif" font-size="150"
+        font-weight="400" text-anchor="middle">brat</text>
+</svg>

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -9,6 +9,7 @@ export const de = {
 	},
 	settings: {
 		general: {
+			heading: "Allgemein",
 			autoEnablePluginsAfterInstallation: {
 				name: "Beta-Plugins nach der Installation automatisch aktivieren",
 				desc: "Wenn aktiviert, werden neu installierte Beta-Plugins standardmäßig automatisch aktiviert. Diese Option kann im Formular zum Hinzufügen eines Plugins pro Plugin angepasst werden.",
@@ -71,6 +72,7 @@ export const de = {
 		betaPluginList: {
 			heading: "Beta-Plugin-Liste",
 			filterPlaceholder: "Plugins filtern",
+			emptyState: "Noch keine Beta-Plugins hinzugefügt.",
 			description: {
 				intro:
 					'Dies ist die Liste der Beta-Plugins, die über den Befehl "add a beta plugin for testing" hinzugefügt wurden. Du kannst die neueste Version verwenden oder eine Version fixieren. Eine fixierte Version ist ein bestimmtes Plugin-Release anhand seines Release-Tags.',
@@ -99,6 +101,7 @@ export const de = {
 			heading: "Beta-Theme-Liste",
 			addBetaTheme: "Beta-Theme hinzufügen",
 			filterPlaceholder: "Themes filtern",
+			emptyState: "Noch keine Beta-Themes hinzugefügt.",
 			deleteThisBetaTheme: "Dieses Beta-Theme löschen",
 			confirmRemoval: "Zum Bestätigen erneut klicken",
 			copyThemeIdentifier: "Theme-Kennung kopieren",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -127,6 +127,7 @@ export const de = {
 		repository: {
 			label: "Repository",
 			placeholder: "Repository (Beispiel: https://GitHub.com/githubusername/repository-name)",
+			pasteTooltip: "Aus Zwischenablage einfügen",
 			enterAddressToValidate: "Gib eine GitHub-Repository-Adresse ein, um sie zu validieren.",
 			addressRequired: "Repository-Adresse ist erforderlich.",
 			validating: "Repository-Adresse wird validiert...",

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -145,10 +145,13 @@ export const de = {
 			selectVersionEllipsis: "Version auswählen...",
 			latestVersion: "Neueste Version",
 			prereleaseSuffix: "(Vorabversion)",
+			useLatestName: "Immer die neueste Version verwenden",
+			useLatestDesc:
+				"Hält dieses Plugin auf der neuesten Version und aktualisiert es automatisch. Deaktivieren, um eine bestimmte Version aus der Liste festzulegen.",
 		},
 		token: {
 			name: "GitHub-Token",
-			desc: "Wähle ein Secret als Token für dieses Repository aus (optional)",
+			desc: "Verwende die Schaltfläche „Link…“, um ein gespeichertes Secret als GitHub-Token für dieses Repository zu verknüpfen (optional).",
 			settingCleared: (repository: string): string => `Token-Einstellung für ${repository} gelöscht`,
 			settingUpdated: (repository: string): string => `Token-Einstellung für ${repository} aktualisiert`,
 		},

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -139,10 +139,13 @@ export const en = {
 			selectVersionEllipsis: "Select a version...",
 			latestVersion: "Latest version",
 			prereleaseSuffix: "(Prerelease)",
+			useLatestName: "Always use the latest version",
+			useLatestDesc:
+				"Keep this plugin on its newest release and update it automatically. Turn this off to pin a specific version from the list.",
 		},
 		token: {
 			name: "GitHub token",
-			desc: "Select a secret as token for this repository (optional)",
+			desc: "Use the Link… button to link a saved secret as the GitHub token for this repository (optional).",
 			settingCleared: (repository: string): string => `Token setting cleared for ${repository}`,
 			settingUpdated: (repository: string): string => `Token setting updated for ${repository}`,
 		},

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -7,6 +7,7 @@ export const en = {
 	},
 	settings: {
 		general: {
+			heading: "General",
 			autoEnablePluginsAfterInstallation: {
 				name: "Auto-enable plugins after installation",
 				desc: 'If enabled beta plugins will be automatically enabled after installtion by default. Note: you can toggle this on and off for each plugin in the "add plugin" form.',
@@ -68,6 +69,7 @@ export const en = {
 		betaPluginList: {
 			heading: "Beta plugin list",
 			filterPlaceholder: "Filter plugins",
+			emptyState: "No beta plugins added yet.",
 			description: {
 				intro:
 					'The following is a list of beta plugins added via the command "add a beta plugin for testing". You can chose to add the latest version or a frozen version. A frozen version is a specific release of a plugin based on its release tag.',
@@ -93,6 +95,7 @@ export const en = {
 			heading: "Beta themes list",
 			addBetaTheme: "Add beta theme",
 			filterPlaceholder: "Filter themes",
+			emptyState: "No beta themes added yet.",
 			deleteThisBetaTheme: "Delete this beta theme",
 			confirmRemoval: "Click once more to confirm removal",
 			copyThemeIdentifier: "Copy theme identifier",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -121,6 +121,7 @@ export const en = {
 		repository: {
 			label: "Repository",
 			placeholder: "Repository (example: https://GitHub.com/githubusername/repository-name)",
+			pasteTooltip: "Paste from clipboard",
 			enterAddressToValidate: "Enter a GitHub repository address to validate it.",
 			addressRequired: "Repository address is required.",
 			validating: "Validating repository address...",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -144,10 +144,12 @@ export const ja = {
 			selectVersionEllipsis: "バージョンを選択...",
 			latestVersion: "最新バージョン",
 			prereleaseSuffix: "（プレリリース）",
+			useLatestName: "常に最新バージョンを使用",
+			useLatestDesc: "このプラグインを最新リリースに保ち、自動的に更新します。オフにすると、一覧から特定のバージョンを固定できます。",
 		},
 		token: {
 			name: "GitHub トークン",
-			desc: "このリポジトリ用のトークンとして使用するシークレットを選択します（任意）",
+			desc: "「Link…」ボタンから、このリポジトリの GitHub トークンとして使う保存済みシークレットをリンクします（任意）。",
 			settingCleared: (repository: string): string => `${repository} のトークン設定をクリアしました`,
 			settingUpdated: (repository: string): string => `${repository} のトークン設定を更新しました`,
 		},

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -125,6 +125,7 @@ export const ja = {
 		repository: {
 			label: "リポジトリ",
 			placeholder: "リポジトリ（例：https://GitHub.com/githubusername/repository-name）",
+			pasteTooltip: "クリップボードから貼り付け",
 			enterAddressToValidate: "検証する GitHub リポジトリアドレスを入力してください。",
 			addressRequired: "リポジトリアドレスが必要です。",
 			validating: "リポジトリアドレスを検証中...",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -9,6 +9,7 @@ export const ja = {
 	},
 	settings: {
 		general: {
+			heading: "一般",
 			autoEnablePluginsAfterInstallation: {
 				name: "インストール後に Beta プラグインを自動で有効化",
 				desc: "有効にすると、新しくインストールした Beta プラグインは既定で自動的に有効になります。個別のプラグインについては「プラグインを追加」フォームで切り替えられます。",
@@ -70,6 +71,7 @@ export const ja = {
 		betaPluginList: {
 			heading: "Beta プラグイン一覧",
 			filterPlaceholder: "プラグインを絞り込み",
+			emptyState: "ベータプラグインはまだ追加されていません。",
 			description: {
 				intro:
 					'以下は、"add a beta plugin for testing" コマンドで追加された Beta プラグインの一覧です。最新バージョンを使うことも、特定のバージョンに固定することもできます。固定バージョンとは、リリースタグに基づく特定のプラグインリリースです。',
@@ -97,6 +99,7 @@ export const ja = {
 			heading: "Beta テーマ一覧",
 			addBetaTheme: "Beta テーマを追加",
 			filterPlaceholder: "テーマを絞り込み",
+			emptyState: "ベータテーマはまだ追加されていません。",
 			deleteThisBetaTheme: "この Beta テーマを削除",
 			confirmRemoval: "もう一度クリックして削除を確認",
 			copyThemeIdentifier: "テーマ識別子をコピー",

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -139,10 +139,12 @@ export const zhCn = {
 			selectVersionEllipsis: "选择版本...",
 			latestVersion: "最新版本",
 			prereleaseSuffix: "（预发布）",
+			useLatestName: "始终使用最新版本",
+			useLatestDesc: "让此插件保持最新发布版本并自动更新。关闭后可从列表中固定某个特定版本。",
 		},
 		token: {
 			name: "GitHub 令牌",
-			desc: "选择一个密钥，作为访问此仓库的令牌（可选）",
+			desc: "使用“Link…”按钮，将已保存的密钥关联为此仓库的 GitHub 令牌（可选）。",
 			settingCleared: (repository: string): string => `已清除 ${repository} 的令牌设置`,
 			settingUpdated: (repository: string): string => `已更新 ${repository} 的令牌设置`,
 		},

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -122,6 +122,7 @@ export const zhCn = {
 		repository: {
 			label: "仓库",
 			placeholder: "仓库（示例：https://GitHub.com/githubusername/repository-name）",
+			pasteTooltip: "从剪贴板粘贴",
 			enterAddressToValidate: "输入 GitHub 仓库地址后会自动验证。",
 			addressRequired: "需要填写仓库地址。",
 			validating: "正在验证仓库地址...",

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -9,6 +9,7 @@ export const zhCn = {
 	},
 	settings: {
 		general: {
+			heading: "常规",
 			autoEnablePluginsAfterInstallation: {
 				name: "安装后自动启用 Beta 插件",
 				desc: "开启后，新安装的 Beta 插件会默认自动启用。你仍然可以在“添加插件”表单中为单个插件单独调整。",
@@ -70,6 +71,7 @@ export const zhCn = {
 		betaPluginList: {
 			heading: "Beta 插件列表",
 			filterPlaceholder: "筛选插件",
+			emptyState: "尚未添加测试插件。",
 			description: {
 				intro:
 					"下方列出已通过 BRAT 添加的 Beta 插件。你可以让插件跟随最新版本，也可以固定到某个发布版本。固定版本指基于 release 标签指定的某个插件版本。",
@@ -94,6 +96,7 @@ export const zhCn = {
 			heading: "Beta 主题列表",
 			addBetaTheme: "添加 Beta 主题",
 			filterPlaceholder: "筛选主题",
+			emptyState: "尚未添加测试主题。",
 			deleteThisBetaTheme: "删除此 Beta 主题",
 			confirmRemoval: "再次点击确认移除",
 			copyThemeIdentifier: "复制主题标识符",

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -37,9 +37,6 @@ export default class AddNewPluginModal extends Modal {
 
 	// Token Validation
 	secretName: string;
-	validToken: boolean | undefined;
-	tokenInputEl: SecretComponent | null = null;
-	validateButton: ButtonComponent | null = null;
 	validator: TokenValidator | null = null;
 
 	// Plugin install action
@@ -356,23 +353,15 @@ export default class AddNewPluginModal extends Modal {
 							}
 							const tokenValue = this.secretName ? this.plugin.app.secretStorage.getSecret(this.secretName) : null;
 							if (tokenValue) {
-								this.validToken = await this.validator?.validateToken(tokenValue, this.address);
-								if (!this.validToken) {
-									this.validateButton?.setButtonText(text.buttons.invalid);
-									this.validateButton?.setDisabled(false);
-								} else {
-									this.validateButton?.setButtonText(text.buttons.valid);
-									this.validateButton?.setDisabled(true);
+								const validToken = await this.validator?.validateToken(tokenValue, this.address);
+								if (validToken && this.address) {
+									// Refresh the version dropdown now that a (valid) token is available.
+									await this.updateRepositoryVersionInfo(this.version, validationStatusEl);
 
-									// Update version dropdown when API key changes
-									if (this.address) {
-										await this.updateRepositoryVersionInfo(this.version, validationStatusEl);
-
-										// Update the secret name for this plugin in the settings if it already exists there
-										if (existBetaPluginInList(this.plugin, this.address)) {
-											updatePluginTokenName(this.plugin, this.address, this.secretName);
-											toastMessage(this.plugin, text.token.settingUpdated(this.address), 3);
-										}
+									// Update the secret name for this plugin in the settings if it already exists there
+									if (existBetaPluginInList(this.plugin, this.address)) {
+										updatePluginTokenName(this.plugin, this.address, this.secretName);
+										toastMessage(this.plugin, text.token.settingUpdated(this.address), 3);
 									}
 								}
 							}
@@ -380,23 +369,8 @@ export default class AddNewPluginModal extends Modal {
 					}),
 				);
 
-			// Initialize validator
+			// Initialize validator (used by the token selector's onChange above).
 			this.validator = new TokenValidator();
-
-			// Validate the current token if we have a secret name
-			if (this.secretName) {
-				const tokenValue = this.plugin.app.secretStorage.getSecret(this.secretName);
-				if (tokenValue) {
-					// Validate asynchronously on initial load
-					void this.validator?.validateToken(tokenValue, this.address).then((isValid) => {
-						this.validToken = isValid;
-						if (this.validToken) {
-							this.validateButton?.setButtonText(text.buttons.valid);
-							this.validateButton?.setDisabled(true);
-						}
-					});
-				}
-			}
 
 			formEl.createDiv("modal-button-container", (buttonContainerEl) => {
 				buttonContainerEl.createEl(

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -24,6 +24,14 @@ export default class AddNewPluginModal extends Modal {
 	version: string;
 	versionSetting: Setting | null = null;
 
+	// "Use latest version" checkbox state. When true, the plugin tracks the latest
+	// release and the version dropdown is greyed out. Seeded per-add from the global
+	// selectLatestPluginVersionByDefault setting; toggling it does not change the global.
+	useLatestVersion: boolean;
+	// Versions loaded for the current repository (used to rebuild the dropdown on toggle).
+	private loadedVersions: ReleaseVersion[] = [];
+	private versionsAvailable = false;
+
 	// Repository Setting
 	repositoryAddressEl: TextComponent | null = null;
 
@@ -60,6 +68,37 @@ export default class AddNewPluginModal extends Modal {
 		this.updateVersion = updateVersion;
 		this.enableAfterInstall = plugin.settings.enableAfterInstall;
 		this.onSubmitted = onSubmitted;
+
+		// Seed the "use latest" checkbox: an explicit prefilled version wins, otherwise
+		// fall back to the user's global default.
+		this.useLatestVersion = this.version ? this.version === "latest" : plugin.settings.selectLatestPluginVersionByDefault;
+		if (this.useLatestVersion) this.version = "latest";
+	}
+
+	/** Grey out / enable the version dropdown to match the "use latest" checkbox. */
+	private applyVersionSelectionState(): void {
+		if (!this.versionSetting) return;
+		if (this.useLatestVersion) {
+			this.versionSetting.settingEl.classList.add("disabled-setting");
+			this.versionSetting.setDisabled(true);
+		} else if (this.versionsAvailable) {
+			// Only re-enable once versions have actually loaded for the current repo.
+			this.versionSetting.settingEl.classList.remove("disabled-setting");
+			this.versionSetting.setDisabled(false);
+			this.updateVersionDropdown(this.versionSetting, this.loadedVersions, this.version);
+		}
+		this.updateAddButtonState();
+	}
+
+	/** Enable "Add plugin" only when the repo is valid and a version choice exists. */
+	private updateAddButtonState(): void {
+		if (this.updateVersion && !this.address) {
+			this.addPluginButton?.setDisabled(true);
+			return;
+		}
+		const repoOk = this.isGitHubRepositoryMatch(this.address);
+		const needsVersion = !this.useLatestVersion && this.version === "";
+		this.addPluginButton?.setDisabled(!repoOk || needsVersion);
 	}
 
 	async submitForm(): Promise<void> {
@@ -87,9 +126,8 @@ export default class AddNewPluginModal extends Modal {
 
 			// Reset modal if we don't close (i.e. because plugin could not be installed)
 			this.cancelButton?.setDisabled(false);
-			this.addPluginButton?.setDisabled(false);
 			this.addPluginButton?.setButtonText(text.buttons.addPlugin);
-			this.versionSetting?.setDisabled(false);
+			this.applyVersionSelectionState();
 
 			return;
 		}
@@ -116,9 +154,8 @@ export default class AddNewPluginModal extends Modal {
 
 		// Reset modal if we don't close (i.e. because plugin could not be installed)
 		this.cancelButton?.setDisabled(false);
-		this.addPluginButton?.setDisabled(false);
 		this.addPluginButton?.setButtonText(text.buttons.addPlugin);
-		this.versionSetting?.setDisabled(false);
+		this.applyVersionSelectionState();
 	}
 
 	private updateVersionDropdown(settingEl: Setting, versions: ReleaseVersion[], selected = ""): void {
@@ -146,7 +183,7 @@ export default class AddNewPluginModal extends Modal {
 				}
 				dropdown.onChange((value: string) => {
 					this.version = value;
-					this.addPluginButton?.setDisabled(this.version === "");
+					this.updateAddButtonState();
 				});
 				dropdown.setValue(selectedVersion);
 
@@ -168,7 +205,7 @@ export default class AddNewPluginModal extends Modal {
 						const modal = new VersionSuggestModal(this.app, this.address, suggestedVersions, selectedVersion, (version: string) => {
 							this.version = version;
 							button.setButtonText(version === "latest" ? text.version.latestVersion : version || text.version.selectVersionEllipsis);
-							this.addPluginButton?.setDisabled(this.version === "");
+							this.updateAddButtonState();
 						});
 						modal.open();
 					});
@@ -213,11 +250,8 @@ export default class AddNewPluginModal extends Modal {
 								}
 							}
 
-							// If the GitHub Repository matches the GitHub pattern, enable the "Add Plugin"
-							if (!this.version) {
-								if (this.isGitHubRepositoryMatch(this.address)) this.addPluginButton?.setDisabled(false);
-								else this.addPluginButton?.setDisabled(true);
-							}
+							// Enable/disable "Add plugin" based on repo validity and version choice.
+							this.updateAddButtonState();
 						});
 
 						addressEl.inputEl.addEventListener("keydown", (e: KeyboardEvent) => {
@@ -277,6 +311,25 @@ export default class AddNewPluginModal extends Modal {
 			// TODO: Find better way to build the modal
 			const validationStatusEl = formEl.createDiv("validation-status");
 			if (!this.address) validationStatusEl.setText(text.repository.enterAddressToValidate);
+
+			// "Use latest version" checkbox with explanatory text, shown to the left of
+			// the version dropdown. When checked, the dropdown below is greyed out and
+			// the plugin tracks the latest release.
+			new Setting(formEl)
+				.setClass("latest-version-setting")
+				.setName(text.version.useLatestName)
+				.setDesc(text.version.useLatestDesc)
+				.addToggle((toggle) => {
+					toggle.setValue(this.useLatestVersion).onChange((value) => {
+						this.useLatestVersion = value;
+						if (value) {
+							this.version = "latest";
+						} else if (this.version === "latest") {
+							this.version = "";
+						}
+						this.applyVersionSelectionState();
+					});
+				});
 
 			// Then add version dropdown
 			this.versionSetting = new Setting(formEl).setClass("version-setting").setClass("disabled-setting");
@@ -481,11 +534,14 @@ export default class AddNewPluginModal extends Modal {
 				validateInputEl?.inputEl.classList.add("valid-repository");
 				validationStatusEl?.setText("");
 
+				this.loadedVersions = versions;
+				this.versionsAvailable = true;
+
 				if (this.versionSetting) {
-					this.versionSetting.settingEl.classList.remove("disabled-setting");
-					this.versionSetting.setDisabled(false);
-					// Add new dropdown to existing version setting
+					// Build the dropdown from the loaded versions, then let the "use latest"
+					// checkbox decide whether it stays greyed out.
 					this.updateVersionDropdown(this.versionSetting, versions, selectedVersion);
+					this.applyVersionSelectionState();
 				}
 			} else {
 				// Add invalid-repository class
@@ -494,6 +550,7 @@ export default class AddNewPluginModal extends Modal {
 				validationStatusEl?.setText(text.repository.noReleasesFound);
 				validationStatusEl?.addClass("validation-status-error");
 
+				this.versionsAvailable = false;
 				this.versionSetting?.settingEl.classList.add("disabled-setting");
 				this.versionSetting?.setDisabled(true);
 				this.addPluginButton?.setDisabled(true);

--- a/src/ui/AddNewPluginModal.ts
+++ b/src/ui/AddNewPluginModal.ts
@@ -246,6 +246,31 @@ export default class AddNewPluginModal extends Modal {
 						setting.setDesc(text.repository.label);
 						addressEl.inputEl.addClass("brat-full-width-input");
 					});
+
+					// Convenience "paste from clipboard" button next to the repository input
+					setting.addExtraButton((pasteBtn) => {
+						pasteBtn
+							.setIcon("clipboard-paste")
+							.setTooltip(text.repository.pasteTooltip)
+							.onClick(() => {
+								void (async () => {
+									try {
+										if (!navigator.clipboard?.readText) return;
+										const pasted = (await navigator.clipboard.readText()).trim();
+										if (!pasted) return;
+
+										this.repositoryAddressEl?.setValue(pasted);
+										this.address = scrubRepositoryUrl(pasted);
+										if (!this.version) {
+											this.addPluginButton?.setDisabled(!this.isGitHubRepositoryMatch(this.address));
+										}
+										await this.updateRepositoryVersionInfo(this.version, validationStatusEl);
+									} catch (error) {
+										console.error("Failed to paste repository address", error);
+									}
+								})();
+							});
+					});
 				});
 			}
 			// Add validation status element (as a separate element)

--- a/src/ui/SettingsTab.ts
+++ b/src/ui/SettingsTab.ts
@@ -53,32 +53,38 @@ export class BratSettingsTab extends PluginSettingTab {
 
 		return [
 			{
-				name: text.general.autoEnablePluginsAfterInstallation.name,
-				desc: text.general.autoEnablePluginsAfterInstallation.desc,
-				control: { type: "toggle", key: "enableAfterInstall" },
-			},
-			{
-				name: text.general.autoUpdatePluginsAtStartup.name,
-				desc: text.general.autoUpdatePluginsAtStartup.desc,
-				control: { type: "toggle", key: "updateAtStartup" },
-			},
-			{
-				name: text.general.autoUpdateThemesAtStartup.name,
-				desc: text.general.autoUpdateThemesAtStartup.desc,
-				control: { type: "toggle", key: "updateThemesAtStartup" },
-			},
-			{
-				name: text.general.selectLatestPluginVersionByDefault.name,
-				desc: text.general.selectLatestPluginVersionByDefault.desc,
-				control: {
-					type: "toggle",
-					key: "selectLatestPluginVersionByDefault",
-				},
-			},
-			{
-				name: text.general.allowIncompatiblePlugins.name,
-				desc: text.general.allowIncompatiblePlugins.desc,
-				control: { type: "toggle", key: "allowIncompatiblePlugins" },
+				type: "group",
+				heading: text.general.heading,
+				items: [
+					{
+						name: text.general.autoEnablePluginsAfterInstallation.name,
+						desc: text.general.autoEnablePluginsAfterInstallation.desc,
+						control: { type: "toggle", key: "enableAfterInstall" },
+					},
+					{
+						name: text.general.autoUpdatePluginsAtStartup.name,
+						desc: text.general.autoUpdatePluginsAtStartup.desc,
+						control: { type: "toggle", key: "updateAtStartup" },
+					},
+					{
+						name: text.general.autoUpdateThemesAtStartup.name,
+						desc: text.general.autoUpdateThemesAtStartup.desc,
+						control: { type: "toggle", key: "updateThemesAtStartup" },
+					},
+					{
+						name: text.general.selectLatestPluginVersionByDefault.name,
+						desc: text.general.selectLatestPluginVersionByDefault.desc,
+						control: {
+							type: "toggle",
+							key: "selectLatestPluginVersionByDefault",
+						},
+					},
+					{
+						name: text.general.allowIncompatiblePlugins.name,
+						desc: text.general.allowIncompatiblePlugins.desc,
+						control: { type: "toggle", key: "allowIncompatiblePlugins" },
+					},
+				],
 			},
 			this.createPluginListDefinition(),
 			this.createThemeListDefinition(),
@@ -540,6 +546,7 @@ export class BratSettingsTab extends PluginSettingTab {
 		return {
 			type: "list",
 			heading: text.betaPluginList.heading,
+			emptyState: text.betaPluginList.emptyState,
 			search: this.createListSearch(text.betaPluginList.filterPlaceholder),
 			addItem: {
 				name: text.betaPluginList.addBetaPlugin,
@@ -548,7 +555,9 @@ export class BratSettingsTab extends PluginSettingTab {
 				},
 			},
 			items: [
-				this.createPluginListDescriptionItem(),
+				// Only show the "edit/remove" guidance when there is at least one plugin;
+				// otherwise the list is empty and the emptyState message is shown instead.
+				...(this.plugin.settings.pluginList.length ? [this.createPluginListDescriptionItem()] : []),
 				...this.plugin.settings.pluginList.map((repository) => {
 					const trackedPlugin = frozenVersions.get(repository);
 					return {
@@ -569,6 +578,7 @@ export class BratSettingsTab extends PluginSettingTab {
 		return {
 			type: "list",
 			heading: text.betaThemeList.heading,
+			emptyState: text.betaThemeList.emptyState,
 			search: this.createListSearch(text.betaThemeList.filterPlaceholder),
 			addItem: {
 				name: text.betaThemeList.addBetaTheme,

--- a/styles.css
+++ b/styles.css
@@ -168,8 +168,29 @@
   float: right;
 }
 
+/* Repository input + paste button sit on one row, input flexes to fill */
+.brat-modal .repository-setting .setting-item-control {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.brat-modal .repository-setting .brat-full-width-input {
+  flex: 1;
+}
+
+/* Modal footer: promotional block left-aligned on a single line */
 .brat-promotional-links-modal {
-  padding: 10px 15px;
+  float: none;
+  padding: 10px 0 0;
+}
+.brat-promotional-links-modal .brat-promotional-links-coffee {
+  padding-left: 0;
+}
+.brat-promotional-links-modal .coffee {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: baseline;
 }
 
 .brat-promotional-links-settings {


### PR DESCRIPTION
### docs: replace low-res brat.jpg with crisp SVG wordmark in README

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

### feat: improve declarative settings UI (General group + list empty states)

Enhancements to the staged declarative settings path (getSettingDefinitions),
which activates once the tab drops its legacy imperative display() override:

- Group the five general toggles under a "General" heading for structural
  consistency with the other grouped sections.
- Add empty-state messages to the beta plugin and beta theme lists, and only
  render the plugin-list "edit/remove" guidance when at least one plugin exists
  so the empty state can actually surface.
- Add the corresponding i18n keys across all four locales (en, de, ja, zh-cn).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

### feat: add clipboard paste button to repo field; tidy modal footer

- Add a "paste from clipboard" button beside the repository input in the
  Add Beta Plugin modal, which fills the field, validates the address, and
  fetches release versions in one click (i18n across all four locales).
- Left-align the modal promotional footer on a single line (scoped to the
  modal; the settings-tab variant is unchanged).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

### feat: "use latest version" checkbox and clearer token label in add-plugin modal

- Add an "Always use the latest version" checkbox above the version dropdown.
  Seeded per-add from the global selectLatestPluginVersionByDefault setting
  (never writes back to it). When checked, the plugin tracks latest, the version
  dropdown is greyed out, and "Add plugin" enables immediately without waiting
  for releases to load. Unchecking requires picking a specific version.
- Centralize the Add-button enable logic (updateAddButtonState) and the dropdown
  grey-out logic (applyVersionSelectionState) so the validation, submit-failure,
  and toggle paths stay consistent.
- Reword the GitHub token description to explain the core "Link…" button (which
  BRAT cannot rename) links a saved secret. All four locales updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

### refactor: remove dead token-validation UI from add-plugin modal

tokenInputEl was never assigned and validateButton was never created in this
modal, so every this.validateButton?.setButtonText/setDisabled call was a no-op
and the this.validToken field only gated those dead calls. Remove the three dead
fields, collapse the token onChange handler to a local validToken that still gates
the version-dropdown refresh, and drop the initial-load validation block whose
only effect was updating the non-existent button. The TokenValidator (used by the
selector onChange) is kept.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
📌 Part of a 9-PR series from a combined code + security review — tracking issue #199.

**Related PRs:** #190 (security · path traversal) · #191 (settings-tab + unload) · #192 (correctness) · #193 (error-handling) · #194 (modal UX + settings polish) · #195 (cleanup) · #196 (migration path) · #197 (addPlugin options) · #198 (githubUtils cleanup)