### PR TITLE
refactor: remove dead save flag; fix AddNewTheme address checks

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,10 +70,8 @@ export function addBetaPluginToList(
 	isIncompatible = false,
 	secretName = "",
 ): void {
-	let save = false;
 	if (!plugin.settings.pluginList.contains(repositoryPath)) {
 		plugin.settings.pluginList.unshift(repositoryPath);
-		save = true;
 	}
 
 	// If it's an existing frozen version plugin, update it instead of checking for duplicates
@@ -88,7 +86,6 @@ export function addBetaPluginToList(
 			tokenName: secretName || existingFrozenPlugin.tokenName,
 			isIncompatible: isIncompatible || undefined,
 		});
-		save = true;
 	} else {
 		plugin.settings.pluginSubListFrozenVersion.unshift({
 			repo: repositoryPath,
@@ -97,11 +94,9 @@ export function addBetaPluginToList(
 			tokenName: secretName || undefined,
 			isIncompatible: isIncompatible || undefined,
 		});
-		save = true;
 	}
-	if (save) {
-		void plugin.saveSettings();
-	}
+	// Every branch above mutates settings, so always persist.
+	void plugin.saveSettings();
 }
 
 /**
@@ -190,10 +185,9 @@ export function updateBetaThemeLastUpdateChecksum(
 	repositoryPath: string,
 	checksum: string,
 ): void {
-	for (const t of plugin.settings.themesList) {
-		if (t.repo === repositoryPath) {
-			t.lastUpdate = checksum;
-			void plugin.saveSettings();
-		}
+	const theme = plugin.settings.themesList.find((t) => t.repo === repositoryPath);
+	if (theme) {
+		theme.lastUpdate = checksum;
+		void plugin.saveSettings();
 	}
 }

--- a/src/ui/AddNewTheme.ts
+++ b/src/ui/AddNewTheme.ts
@@ -1,4 +1,5 @@
 import { ButtonComponent, Modal, Setting } from "obsidian";
+import { scrubRepositoryUrl } from "../features/githubUtils";
 import { themeSave } from "../features/themes";
 import { getTranslations } from "../i18n";
 import type BratPlugin from "../main";
@@ -26,7 +27,7 @@ export default class AddNewTheme extends Modal {
 	async submitForm(): Promise<void> {
 		const text = getTranslations();
 		if (this.address === "") return;
-		const scrubbedAddress = this.address.replace("https://github.com/", "");
+		const scrubbedAddress = scrubRepositoryUrl(this.address);
 		if (existBetaThemeinInList(this.plugin, scrubbedAddress)) {
 			toastMessage(this.plugin, text.addBetaThemeModal.alreadyInList, 10);
 			return;
@@ -53,7 +54,7 @@ export default class AddNewTheme extends Modal {
 					this.address = value.trim();
 				});
 				textEl.inputEl.addEventListener("keydown", (e: KeyboardEvent) => {
-					if (e.key === "Enter" && this.address !== " ") {
+					if (e.key === "Enter" && this.address !== "") {
 						e.preventDefault();
 						void this.submitForm();
 					}


### PR DESCRIPTION
### refactor: remove dead save flag, fix AddNewTheme address checks

- settings.addBetaPluginToList: every branch set save = true, so the flag and its
  guard were noise. Save unconditionally.
- settings.updateBetaThemeLastUpdateChecksum: repos are unique, so use find() and
  save once instead of looping and calling saveSettings() per match.
- AddNewTheme: the Enter handler compared this.address !== " " (a single space)
  instead of "", and submitForm scrubbed the URL with a bare
  replace("https://github.com/", "") that missed http://, trailing slashes and
  .git. Reuse scrubRepositoryUrl for parity with the plugin flow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
📌 Part of a 9-PR series from a combined code + security review — tracking issue #199.

**Related PRs:** #190 (security · path traversal) · #191 (settings-tab + unload) · #192 (correctness) · #193 (error-handling) · #194 (modal UX + settings polish) · #195 (cleanup) · #196 (migration path) · #197 (addPlugin options) · #198 (githubUtils cleanup)