### PR TITLE
fix: resolve migration log path from manifest.dir, not a hard-coded folder name

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,10 @@ export default class BratPlugin extends Plugin {
 		this.loadSettings()
 			.then(async () => {
 				// Migrate tokens to SecretStorage (Obsidian 1.11.4+)
-				await migrateTokensToSecretStorage(this.app, this.settings, () => this.saveSettings());
+				// Use the plugin's actual folder (manifest.dir) rather than a hard-coded
+				// name so the migration log resolves correctly for renamed/dev installs.
+				const pluginDir = this.manifest.dir ?? `${this.app.vault.configDir}/plugins/${this.manifest.id}`;
+				await migrateTokensToSecretStorage(this.app, this.settings, () => this.saveSettings(), pluginDir);
 
 				this.app.workspace.onLayoutReady(() => {
 					this.addSettingTab(this.settingsTab);

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -15,11 +15,12 @@ const MIGRATION_LOG_KEY = "brat-migrations";
  */
 async function hasMigrationRun(
 	app: App,
+	pluginDir: string,
 	migrationId: string,
 ): Promise<boolean> {
 	try {
 		const logData = await app.vault.adapter.read(
-			`${app.vault.configDir}/plugins/obsidian42-brat/${MIGRATION_LOG_KEY}.json`,
+			`${pluginDir}/${MIGRATION_LOG_KEY}.json`,
 		);
 		const log = JSON.parse(logData) as MigrationLog;
 		return log.appliedMigrations.includes(migrationId);
@@ -33,10 +34,11 @@ async function hasMigrationRun(
  */
 async function markMigrationComplete(
 	app: App,
+	pluginDir: string,
 	migrationId: string,
 ): Promise<void> {
 	try {
-		const logPath = `${app.vault.configDir}/plugins/obsidian42-brat/${MIGRATION_LOG_KEY}.json`;
+		const logPath = `${pluginDir}/${MIGRATION_LOG_KEY}.json`;
 		let log: MigrationLog = { appliedMigrations: [] };
 
 		try {
@@ -76,11 +78,12 @@ export async function migrateTokensToSecretStorage(
 	app: App,
 	settings: Settings,
 	saveSettings: () => Promise<void>,
+	pluginDir: string,
 ): Promise<void> {
 	const MIGRATION_ID = "tokens-to-secretstorage-v1";
 
 	// Check if migration already ran
-	if (await hasMigrationRun(app, MIGRATION_ID)) {
+	if (await hasMigrationRun(app, pluginDir, MIGRATION_ID)) {
 		return;
 	}
 
@@ -169,7 +172,7 @@ export async function migrateTokensToSecretStorage(
 		}
 
 		// Mark migration as complete
-		await markMigrationComplete(app, MIGRATION_ID);
+		await markMigrationComplete(app, pluginDir, MIGRATION_ID);
 	} catch (error) {
 		console.error("BRAT: Failed to migrate tokens to SecretStorage:", error);
 		// Don't throw - allow plugin to continue loading


### PR DESCRIPTION
### fix: resolve migration log path from manifest.dir, not hard-coded folder name

hasMigrationRun/markMigrationComplete built the migration-log path from a
hard-coded ".obsidian/plugins/obsidian42-brat" segment, which breaks for renamed
or dev installs (the migration would re-run or never record). Thread the actual
plugin directory (this.manifest.dir, with a manifest.id-based fallback) through
migrateTokensToSecretStorage into both helpers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

---
📌 Part of a 9-PR series from a combined code + security review — tracking issue #199.

**Related PRs:** #190 (security · path traversal) · #191 (settings-tab + unload) · #192 (correctness) · #193 (error-handling) · #194 (modal UX + settings polish) · #195 (cleanup) · #196 (migration path) · #197 (addPlugin options) · #198 (githubUtils cleanup)