### PR TITLE
Guard against plugin id-collision overwriting non-BRAT-managed plugins

### DIFF
--- a/src/features/BetaPlugins.ts
+++ b/src/features/BetaPlugins.ts
@@ -9,6 +9,7 @@ import { addBetaPluginToList } from "../settings";
 import AddNewPluginModal from "../ui/AddNewPluginModal";
 import { isConnectedToInternet } from "../utils/internetconnection";
 import { toastMessage } from "../utils/notifications";
+import { isNonBratPluginIdCollision } from "../utils/utils";
 import {
 	grabCommmunityPluginList,
 	grabReleaseFileFromRepository,
@@ -508,6 +509,25 @@ export default class BetaPlugins {
 			if (!updatePluginFiles || forceReinstall) {
 				const releaseFiles = await getRelease();
 				if (releaseFiles === null) return false;
+
+				// id-collision protection: the install folder is derived from the release's
+				// self-declared manifest id, so refuse to overwrite a plugin BRAT does not
+				// manage (e.g. one installed from the community store) that already owns this id.
+				if (
+					isNonBratPluginIdCollision({
+						pluginId: primaryManifest.id,
+						repositoryPath,
+						installedPluginIds: Object.keys(this.plugin.app.plugins.manifests),
+						bratTrackedRepos: this.plugin.settings.pluginList,
+					})
+				) {
+					const msg = `${repositoryPath}\nInstall aborted: a different, already-installed plugin uses the id "${primaryManifest.id}". BRAT will not overwrite a plugin it does not manage. If you installed "${primaryManifest.id}" from the community store, remove it first; otherwise this repository may be attempting to hijack that plugin's id.`;
+					await this.plugin.log(msg, true);
+					// Always surface this regardless of the notifications setting — it is a security refusal.
+					new Notice(`BRAT\n${msg}`, noticeTimeout * 1000);
+					return false;
+				}
+
 				await this.writeReleaseFilesToPluginFolder(primaryManifest.id, releaseFiles);
 				addBetaPluginToList(
 					this.plugin,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,27 @@
+/**
+ * id-collision protection.
+ *
+ * BRAT derives a plugin's install folder from the release's self-declared
+ * manifest `id`. Without a guard, a repository could declare a popular
+ * plugin's id (e.g. "dataview") and silently overwrite that other plugin's
+ * installed files. A collision exists when a plugin with `pluginId` is already
+ * installed in the vault, yet the repository being installed is not one BRAT
+ * tracks — meaning some other, non-BRAT-managed plugin currently owns that id.
+ */
+export function isNonBratPluginIdCollision({
+	pluginId,
+	repositoryPath,
+	installedPluginIds,
+	bratTrackedRepos,
+}: {
+	pluginId: string;
+	repositoryPath: string;
+	installedPluginIds: string[];
+	bratTrackedRepos: string[];
+}): boolean {
+	return installedPluginIds.includes(pluginId) && !bratTrackedRepos.includes(repositoryPath);
+}
+
 export function createGitHubResourceLink(
 	githubResource: string,
 	optionalText?: string,


### PR DESCRIPTION
## Summary

BRAT derives a plugin's install folder (`.obsidian/plugins/<id>/`) from the downloaded release's self-declared `manifest.json` `id` field. There is currently no check that this `id` is not already in use by a *different* plugin that BRAT does not manage. As a result, a repository whose manifest declares a popular plugin's id (e.g. `id: "dataview"`) will, on install, silently overwrite that other plugin's installed files.

This PR adds a pre-write guard so BRAT refuses to overwrite a plugin it does not manage, and tells the user why.

## The finding

- Install target folder name = release manifest `id` (`writeReleaseFilesToPluginFolder` in `src/features/BetaPlugins.ts`).
- On a fresh install, files are written to that folder with no check against ids already present in the vault's plugin list.
- BRAT tracks its own installs by repository path in `settings.pluginList`, so a folder/id owned by a non-BRAT plugin (e.g. one installed from the community store) is indistinguishable at write time and gets overwritten silently.

This was identified through an independent source-code security audit of the plugin. It is a moderate hardening improvement, not a remotely triggerable vulnerability — it requires the user to attempt installing the malicious repo — but the silent overwrite of an unrelated, trusted plugin is worth guarding against.

## The fix

In the fresh-install path of `addPlugin`, before writing files, check:

- a plugin with the target `id` is already installed in the vault (`app.plugins.manifests`), **and**
- the repository being installed is **not** in BRAT's tracked `pluginList`.

If both hold, the install is refused and an Obsidian `Notice` is shown naming the offending repository and id. The `Notice` is shown regardless of the notifications setting because it is a security refusal.

Reinstalls and updates of repositories BRAT already tracks are unaffected (their repo is in `pluginList`). Installing a brand-new id is unaffected (no existing manifest for that id).

The collision test is factored into a pure helper `isNonBratPluginIdCollision` in `src/utils/utils.ts` for isolation/testability.

## Notes

- Scope is intentionally minimal — no unrelated refactoring.
- `npm run build` passes cleanly. This repo has no test runner configured, so no automated test was added (the guard is a pure function should one be added later).
